### PR TITLE
fix: buffer scaling issue leading to protocol error

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -325,6 +325,14 @@ impl Dispatch<wl_output::WlOutput, usize> for NLockState {
                 state.surfaces[*data].output_name = Some(name);
             }
             wl_output::Event::Scale { factor } => {
+                debug!(
+                    "Set output scale for '{}' to {factor}",
+                    state.surfaces[*data]
+                        .output_name
+                        .as_ref()
+                        .unwrap_or(&"".to_string())
+                );
+
                 state.surfaces[*data].output_scale = factor;
             }
             wl_output::Event::Done => {


### PR DESCRIPTION
- buffer scaling was causing protocol errors on some compositors, due to acked dimensions being different.
- solution here is simply to let the compositor handle scaling, at least for now.

closes #19