### PR TITLE
feat(render): add buffer scaling based on Wayland output scale

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -26,6 +26,7 @@ The following correspond directly to configuration options. See
 - `--font-family <STRING>`, sets the font family
 - `--font-slant <SLANT>`, sets the font slant
 - `--font-weight <WEIGHT>`, sets the font weight
+- `--use-dpi-scaling <BOOL>`, scale font size by display output DPI
 - `--mask-char <STRING>`, sets the mask character for the input box
 - `--input-width <FLOAT>`, sets tthe relative width of the input box
 - `--input-padding_x <FLOAT>`, sets the relative horizontal padding of the input box

--- a/doc/config.md
+++ b/doc/config.md
@@ -32,6 +32,7 @@ frameBorderFail = "#FF0000FF"       # frame border error color
 # Font section configures text display.
 [font]
 size = 72.0     # font size, in points
+useDpiScaling = false   # whether to scale font size based on output DPI
 
 # Font family uses Cairo's toy font API, generally, standard CSS names
 # like `monospace`, `serif`, etc. should work. Leaving it empty (or invalid)

--- a/src/args.rs
+++ b/src/args.rs
@@ -169,6 +169,7 @@ pub struct NLockArgsFont {
     pub family: Option<String>,
     pub slant: Option<FontSlant>,
     pub weight: Option<FontWeight>,
+    pub use_dpi_scaling: Option<bool>,
 }
 
 impl LoadArgMatches for NLockArgsFont {
@@ -177,12 +178,14 @@ impl LoadArgMatches for NLockArgsFont {
         let family = args_get_value!(matches, String, "font_family");
         let slant = args_get_value!(matches, FontSlant, "font_slant");
         let weight = args_get_value!(matches, FontWeight, "font_weight");
+        let use_dpi_scaling = args_get_value!(matches, bool, "use_dpi_scaling");
 
         Self {
             size,
             family,
             slant,
             weight,
+            use_dpi_scaling,
         }
     }
 }
@@ -359,6 +362,11 @@ fn build_cli() -> Command {
             "Sets the font weight",
             "WEIGHT",
             FontWeight
+        ))
+        .arg(bool_arg!(
+            "use_dpi_scaling",
+            "use-dpi-scaling",
+            "Scale font size based on output DPI"
         ))
         .arg(string_arg!(
             "mask_char",

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -45,8 +45,9 @@ pub struct NLockBufferGuard<'a> {
 impl<'a> NLockBufferGuard<'a> {
     /// Attaches, damages, and commits the current buffer onto the specified
     /// surface.
-    pub fn commit_to(&mut self, surface: &wl_surface::WlSurface) {
+    pub fn commit_to(&mut self, surface: &wl_surface::WlSurface, scale: i32) {
         surface.attach(Some(self.wl_buffer), 0, 0);
+        surface.set_buffer_scale(scale);
         surface.damage(0, 0, i32::MAX, i32::MAX);
         surface.commit();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,6 +178,9 @@ pub struct NLockConfigFont {
 
     #[serde(default = "default_font_weight")]
     pub weight: FontWeight,
+
+    #[serde(default = "default_font_use_dpi_scaling", rename = "useDpiScaling")]
+    pub use_dpi_scaling: bool,
 }
 
 impl Default for NLockConfigFont {
@@ -187,6 +190,7 @@ impl Default for NLockConfigFont {
             family: default_font_family(),
             slant: default_font_slant(),
             weight: default_font_weight(),
+            use_dpi_scaling: default_font_use_dpi_scaling(),
         }
     }
 }
@@ -197,6 +201,7 @@ impl LoadArgOverrides for NLockConfigFont {
         set_if_some_string!(self.family, &args.font.family);
         set_if_some!(self.slant, args.font.slant);
         set_if_some!(self.weight, args.font.weight);
+        set_if_some!(self.use_dpi_scaling, args.font.use_dpi_scaling);
     }
 }
 
@@ -214,6 +219,10 @@ fn default_font_slant() -> FontSlant {
 
 fn default_font_weight() -> FontWeight {
     FontWeight::Normal
+}
+
+fn default_font_use_dpi_scaling() -> bool {
+    false
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- scale buffers based on Wayland output scale
- fix font scaling to use 96 DPI by default
- add config option to scale fonts by display DPI (classic)
- add documentation for `useDpiScaling` option