### PR TITLE
feat: add subcommand for shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +888,7 @@ dependencies = [
  "cairo-rs",
  "chrono",
  "clap",
+ "clap_complete",
  "config",
  "dirs",
  "gdk-pixbuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ atomic_enum = "0.3.0"
 cairo-rs = { version = "0.21.2", features = [ "png" ] }
 chrono = "0.4.42"
 clap = { version = "4.5.53", features = [ "derive" ] }
+clap_complete = "4.5.64"
 config = "0.15.18"
 dirs = "6.0.0"
 gdk-pixbuf = "0.21.5"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -43,3 +43,26 @@ The following correspond directly to configuration options. See
 - `--image-path <PATH>`, path to a background image
 - `--image-scale <SCALE MODE>`, sets the image scaling mode
 
+## Shell Completions
+
+nlock supports self-generation of shell completions for common shells.
+
+To generate completions for your current shell, run:
+
+```sh
+$ nlock completions
+```
+
+This will display a shell completion script for your current shell. The process
+of using this script is shell-specific, but typically, it should be written to
+a file and loaded on startup.
+
+If shell detection fails, try specifying the shell explicitly, using Zsh as an
+example:
+
+```sh
+$ nlock completions /usr/bin/zsh
+```
+
+If generation continues to fail, your shell is likely unsupported.
+


### PR DESCRIPTION
- add `clap_complete` crate for shell completion generation
- add `completions` subcommand to invoke `clap_complete` with a detected or specified shell
- update documentation to include a section on shell completions