### PR TITLE
refactor(render): move rendering to separate module

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -15,7 +15,7 @@ use clap::{
 };
 use clap_complete::{Shell, aot::generate as generate_completions};
 
-use crate::surface::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, Rgba};
+use crate::util::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, Rgba};
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum LogLevel {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, anyhow};
 use atomic_enum::atomic_enum;
 use pam_rs::{Client, PamFlag};
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, warn};
+use tracing::debug;
 use zeroize::Zeroizing;
 
 use crate::config::NLockConfig;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
-use nix::{
-    sys::mman::{MapFlags, ProtFlags, mmap, munmap},
-    unistd::ftruncate,
-};
 use std::{
     os::{fd::AsFd, raw::c_void},
     ptr::NonNull,
@@ -12,6 +8,11 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+};
+
+use nix::{
+    sys::mman::{MapFlags, ProtFlags, mmap, munmap},
+    unistd::ftruncate,
 };
 use wayland_client::{
     Dispatch, QueueHandle,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 
 use crate::{
     args::NLockArgs,
-    surface::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, Rgba},
+    util::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, Rgba},
 };
 
 const CONFIG_FILE_NAME: &str = "nlock.toml";

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
+use std::{
+    os::fd::{AsFd, AsRawFd, BorrowedFd},
+    sync::atomic::Ordering,
+};
+
 use anyhow::{Result, anyhow};
 use mio::{Events, Interest, Poll, Token, unix::SourceFd};
 use nix::{
     sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags},
     unistd::read,
-};
-use std::{
-    os::fd::{AsFd, AsRawFd, BorrowedFd},
-    sync::atomic::Ordering,
 };
 use wayland_client::{EventQueue, QueueHandle, backend::ReadEventsGuard};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,22 +4,16 @@
 pub mod args;
 pub mod auth;
 pub mod buffer;
+pub mod cairo_ext;
 pub mod config;
 pub mod event;
-pub mod cairo_ext;
+pub mod render;
 pub mod seat;
 pub mod state;
 pub mod surface;
 pub mod util;
 
 use std::sync::atomic::Ordering;
-
-use crate::{
-    args::run_cli,
-    auth::{AuthConfig, AuthRequest, run_auth_loop},
-    config::NLockConfig,
-    state::NLockState,
-};
 
 use anyhow::{Result, bail};
 
@@ -29,6 +23,13 @@ use nix::sys::prctl;
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 use wayland_client::Connection;
+
+use crate::{
+    args::run_cli,
+    auth::{AuthConfig, AuthRequest, run_auth_loop},
+    config::NLockConfig,
+    state::NLockState,
+};
 
 async fn start(config: NLockConfig) -> Result<()> {
     // Prevent ptrace from attaching to nlock

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026, Nathan Gill
+
+use anyhow::{Result, anyhow, bail};
+use cairo::SurfacePattern;
+use tracing::warn;
+
+use crate::{
+    auth::AuthState,
+    cairo_ext::CairoExt,
+    config::NLockConfig,
+    util::{BackgroundImageScale, BackgroundType},
+};
+
+pub const DEFAULT_DPI: f64 = 96.0;
+
+pub struct NLockRenderBackgroundArgs<'a> {
+    pub buf_height: f64,
+    pub buf_width: f64,
+    pub context: &'a cairo::Context,
+    pub image: Option<&'a cairo::ImageSurface>,
+}
+
+impl<'a> NLockRenderBackgroundArgs<'a> {
+    fn get_buffer_dimensions(&self) -> Result<(f64, f64)> {
+        if self.buf_width <= 0.0 || self.buf_height <= 0.0 {
+            bail!(
+                "Invalid width or height, {}x{}",
+                self.buf_width,
+                self.buf_height
+            );
+        }
+
+        Ok((self.buf_width, self.buf_height))
+    }
+}
+
+pub struct NLockRenderOverlayArgs<'a> {
+    pub auth_state: AuthState,
+    pub buf_height: f64,
+    pub buf_width: f64,
+    pub context: &'a cairo::Context,
+    pub pwd_len: usize,
+}
+
+impl<'a> NLockRenderOverlayArgs<'a> {
+    fn get_buffer_dimensions(&self) -> Result<(f64, f64)> {
+        if self.buf_width <= 0.0 || self.buf_height <= 0.0 {
+            bail!(
+                "Invalid width or height, {}x{}",
+                self.buf_width,
+                self.buf_height
+            );
+        }
+
+        Ok((self.buf_width, self.buf_height))
+    }
+}
+
+#[derive(Default)]
+pub struct NLockRenderer {
+    dpi: Option<f64>,
+    subpixel_order: Option<cairo::SubpixelOrder>,
+}
+
+impl NLockRenderer {
+    pub fn set_dpi<T>(&mut self, dpi: T)
+    where
+        T: Into<f64>,
+    {
+        let dpi: f64 = dpi.into();
+
+        if dpi.is_infinite() || dpi.is_nan() || dpi <= 0.0 {
+            warn!("Invalid DPI {dpi}, falling back to {DEFAULT_DPI}");
+            self.dpi = Some(DEFAULT_DPI);
+        } else {
+            self.dpi = Some(dpi);
+        }
+    }
+
+    pub fn set_subpixel_order(&mut self, order: cairo::SubpixelOrder) {
+        self.subpixel_order = Some(order);
+    }
+
+    fn clear_background(&self, context: &cairo::Context) -> Result<()> {
+        context.save()?;
+        context.set_operator(cairo::Operator::Source);
+        context.set_source_rgba(0.0, 0.0, 0.0, 0.0);
+        context.paint()?;
+        context.restore()?;
+
+        Ok(())
+    }
+
+    fn reset_cairo_context(&self, context: &cairo::Context) -> Result<()> {
+        context.set_antialias(cairo::Antialias::Best);
+        self.clear_background(context)?;
+        context.identity_matrix();
+
+        Ok(())
+    }
+
+    fn configure_cairo_font(&self, config: &NLockConfig, context: &cairo::Context) -> Result<()> {
+        let mut fo = cairo::FontOptions::new()?;
+        fo.set_hint_style(cairo::HintStyle::Full);
+        fo.set_antialias(cairo::Antialias::Subpixel);
+        fo.set_subpixel_order(self.subpixel_order.unwrap_or(cairo::SubpixelOrder::Default));
+
+        context.set_font_options(&fo);
+        context.select_font_face(
+            &config.font.family,
+            cairo::FontSlant::from(config.font.slant),
+            cairo::FontWeight::from(config.font.weight),
+        );
+
+        let dpi = self.dpi.unwrap_or(DEFAULT_DPI);
+        context.set_font_size((config.font.size / 72.0) * dpi);
+
+        Ok(())
+    }
+
+    fn draw_rounded_rect(context: &cairo::Context, x: f64, y: f64, w: f64, h: f64, r: f64) {
+        context.new_sub_path();
+        context.arc(x + w - r, y + r, r, -90f64.to_radians(), 0f64.to_radians());
+        context.arc(
+            x + w - r,
+            y + h - r,
+            r,
+            0f64.to_radians(),
+            90f64.to_radians(),
+        );
+        context.arc(x + r, y + h - r, r, 90f64.to_radians(), 180f64.to_radians());
+        context.arc(x + r, y + r, r, 180f64.to_radians(), 270f64.to_radians());
+        context.close_path();
+    }
+
+    fn set_frame_border_color(
+        &self,
+        config: &NLockConfig,
+        context: &cairo::Context,
+        auth_state: AuthState,
+    ) {
+        match auth_state {
+            AuthState::Idle => context.ext_set_source_rgba(config.colors.frame_border_idle),
+            AuthState::Success => context.ext_set_source_rgba(config.colors.frame_border_success),
+            AuthState::Fail => context.ext_set_source_rgba(config.colors.frame_border_fail),
+        }
+    }
+
+    fn draw_background_image(
+        &self,
+        context: &cairo::Context,
+        image: &cairo::ImageSurface,
+        buf_width: f64,
+        buf_height: f64,
+        mode: BackgroundImageScale,
+    ) -> Result<()> {
+        let width = image.width() as f64;
+        let height = image.height() as f64;
+
+        match mode {
+            BackgroundImageScale::Stretch => {
+                context.scale(buf_width / width, buf_height / height);
+                context.set_source_surface(image, 0.0, 0.0)?;
+            }
+            BackgroundImageScale::Center => {
+                context.set_source_surface(
+                    image,
+                    (buf_width / 2.0 - width / 2.0).floor(),
+                    (buf_height / 2.0 - height / 2.0).floor(),
+                )?;
+            }
+            BackgroundImageScale::Tile => {
+                let pattern = SurfacePattern::create(image);
+                pattern.set_extend(cairo::Extend::Repeat);
+                context.set_source(pattern)?;
+            }
+            BackgroundImageScale::Fit => {
+                let buf_ratio = buf_width / buf_height;
+                let bg_ratio = width / height;
+
+                if buf_ratio > bg_ratio {
+                    let scale = buf_height / height;
+                    context.scale(scale, scale);
+                    context.set_source_surface(
+                        image,
+                        buf_width / 2.0 / scale - width / 2.0,
+                        0.0,
+                    )?;
+                } else {
+                    let scale = buf_width / width;
+                    context.scale(scale, scale);
+                    context.set_source_surface(
+                        image,
+                        0.0,
+                        buf_height / 2.0 / scale - height / 2.0,
+                    )?;
+                }
+            }
+            BackgroundImageScale::Fill => {
+                let buf_ratio = buf_width / buf_height;
+                let bg_ratio = width / height;
+
+                if buf_ratio > bg_ratio {
+                    let scale = buf_width / width;
+                    context.scale(scale, scale);
+                    context.set_source_surface(
+                        image,
+                        0.0,
+                        buf_height / 2.0 / scale - height / 2.0,
+                    )?;
+                } else {
+                    let scale = buf_height / height;
+                    context.scale(scale, scale);
+                    context.set_source_surface(
+                        image,
+                        buf_width / 2.0 / scale - width / 2.0,
+                        0.0,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn draw_overlay(
+        &self,
+        config: &NLockConfig,
+        context: &cairo::Context,
+        auth_state: AuthState,
+        pwd_len: usize,
+        buf_width: f64,
+        buf_height: f64,
+    ) -> Result<()> {
+        // Reset the context for fresh rendering
+        self.reset_cairo_context(context)?;
+
+        // Draw border colour
+        context.save()?;
+        self.set_frame_border_color(config, context, auth_state);
+        context.set_line_width(config.frame.border);
+
+        let frame_offset = config.frame.border / 2.0;
+        let frame_w = buf_width - (frame_offset * 2.0);
+        let frame_h = buf_height - (frame_offset * 2.0);
+
+        Self::draw_rounded_rect(
+            context,
+            frame_offset,
+            frame_offset,
+            frame_w,
+            frame_h,
+            config.frame.radius,
+        );
+        context.stroke()?;
+        context.restore()?;
+
+        // Skip drawing input box if the password is empty and config flag set
+        if pwd_len == 0 && config.input.hide_when_empty {
+            return Ok(());
+        }
+
+        self.configure_cairo_font(config, context)?;
+
+        let fe = context.font_extents()?;
+
+        let padding_x = config.input.padding_x * buf_width;
+        let padding_y = config.input.padding_y * buf_height;
+
+        // Calculate text extents here, so input box width can be determined
+        let text = config.input.mask_char.repeat(pwd_len);
+        let text_ext = context.text_extents(text.as_str())?;
+
+        let mut inner_w = buf_width * config.input.width;
+
+        if config.input.fit_to_content {
+            // Cap computed width to specified width
+            inner_w = text_ext.width().min(inner_w);
+        }
+
+        let inner_h = fe.height();
+        let inner_x = (buf_width - inner_w) / 2.0;
+        let inner_y = (buf_height - inner_h) / 2.0;
+
+        let outer_h = inner_h + (padding_y * 2.0) + config.input.border;
+        let outer_w = inner_w + (padding_x * 2.0) + config.input.border;
+        let outer_x = (buf_width - outer_w) / 2.0;
+        let outer_y = (buf_height - outer_h) / 2.0;
+
+        context.save()?;
+
+        // Draw the outer rectangle, including padding
+        // Outer rectangle should have rounded corners
+        Self::draw_rounded_rect(
+            context,
+            outer_x,
+            outer_y,
+            outer_w,
+            outer_h,
+            config.input.radius * outer_h, // radius is relative, Cairo requires absolute
+        );
+        context.ext_set_source_rgba(config.colors.input_bg);
+        context.fill_preserve()?;
+        context.ext_set_source_rgba(config.colors.input_border);
+        context.set_line_width(config.input.border);
+        context.stroke_preserve()?;
+        context.clip();
+
+        // Clip text to the inner rectangle
+        context.rectangle(inner_x, inner_y, inner_w, inner_h);
+        context.clip();
+
+        let text_x = inner_x + (inner_w - text_ext.width()) / 2.0 - text_ext.x_bearing();
+        let text_y = inner_y + (inner_h - fe.descent()) / 2.0 + fe.ascent() / 2.0;
+
+        // Actually draw the text
+        context.ext_set_source_rgba(config.colors.text);
+        context.move_to(text_x, text_y);
+        context.show_text(text.as_str())?;
+
+        context.restore()?;
+
+        Ok(())
+    }
+
+    pub fn render_background(
+        &mut self,
+        config: &NLockConfig,
+        args: NLockRenderBackgroundArgs,
+    ) -> Result<()> {
+        let (buf_width, buf_height) = args.get_buffer_dimensions()?;
+
+        self.reset_cairo_context(args.context)?;
+
+        match config.general.bg_type {
+            BackgroundType::Color => {
+                args.context.ext_set_source_rgba(config.colors.bg);
+                args.context.set_operator(cairo::Operator::Source);
+            }
+            BackgroundType::Image => {
+                let image = args
+                    .image
+                    .ok_or(anyhow!("Surface in image mode, but no image set!"))?;
+                self.draw_background_image(
+                    args.context,
+                    image,
+                    buf_width,
+                    buf_height,
+                    config.image.scale,
+                )?;
+            }
+        }
+        args.context.paint()?;
+
+        Ok(())
+    }
+
+    pub fn render_overlay(
+        &mut self,
+        config: &NLockConfig,
+        args: NLockRenderOverlayArgs,
+    ) -> Result<()> {
+        let (buf_width, buf_height) = args.get_buffer_dimensions()?;
+
+        self.draw_overlay(
+            config,
+            args.context,
+            args.auth_state,
+            args.pwd_len,
+            buf_width,
+            buf_height,
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/seat.rs
+++ b/src/seat.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
+use std::{os::fd::OwnedFd, sync::atomic::Ordering, time::Duration};
+
 use anyhow::{Result, anyhow};
 use nix::sys::{time::TimeSpec, timerfd::Expiration};
-use std::{os::fd::OwnedFd, sync::atomic::Ordering, time::Duration};
 use tracing::{debug, warn};
 use wayland_client::{
     Connection, Dispatch, QueueHandle, WEnum,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use anyhow::{Result, anyhow, bail};
 use cairo::ImageSurface;
@@ -26,9 +28,9 @@ use wayland_protocols::ext::session_lock::v1::client::{
 use zeroize::Zeroizing;
 
 use crate::auth::{AtomicAuthState, AuthState};
+use crate::cairo_ext::{ImageSurfaceExt, SubpixelOrderExt};
 use crate::config::NLockConfig;
-use crate::cairo_ext::ImageSurfaceExt;
-use crate::surface::BackgroundType;
+use crate::util::BackgroundType;
 use crate::{
     auth::AuthRequest,
     seat::{NLockSeat, NLockXkb},
@@ -315,9 +317,12 @@ impl Dispatch<wl_output::WlOutput, usize> for NLockState {
                 model: _,
                 transform: _,
             } => {
-                state.surfaces[*data].subpixel = Some(subpixel);
+                state.surfaces[*data]
+                    .set_subpixel_order(cairo::SubpixelOrder::from_wl_subpixel(subpixel));
 
-                if let Err(e) = state.surfaces[*data].set_physical_dimensions(physical_width, physical_height) {
+                if let Err(e) =
+                    state.surfaces[*data].set_physical_dimensions(physical_width, physical_height)
+                {
                     warn!("Failed to set output physical dimensions: {e}");
                 }
             }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
-use std::{str::FromStr, sync::atomic::Ordering};
+use std::sync::atomic::Ordering;
 
 use anyhow::{Result, anyhow, bail};
-use cairo::SurfacePattern;
-use clap::ValueEnum;
-use serde::{Deserialize, de};
 use tracing::{debug, trace, warn};
 use wayland_client::{
-    Dispatch, QueueHandle, WEnum,
+    Dispatch, QueueHandle,
     protocol::{wl_compositor, wl_output, wl_shm, wl_subcompositor, wl_subsurface, wl_surface},
 };
 use wayland_protocols::ext::session_lock::v1::client::{
@@ -17,125 +14,12 @@ use wayland_protocols::ext::session_lock::v1::client::{
 };
 
 use crate::{
-    auth::AuthState, buffer::NLockBuffer, cairo_ext::CairoExt, config::NLockConfig,
+    auth::AuthState,
+    buffer::NLockBuffer,
+    config::NLockConfig,
+    render::{DEFAULT_DPI, NLockRenderBackgroundArgs, NLockRenderOverlayArgs, NLockRenderer},
     state::NLockState,
 };
-
-const DEFAULT_DPI: f64 = 96.0;
-
-#[derive(Debug, Copy, Clone)]
-pub struct Rgba {
-    pub r: f64,
-    pub g: f64,
-    pub b: f64,
-    pub a: f64,
-}
-
-impl Rgba {
-    pub fn new(r: f64, g: f64, b: f64, a: f64) -> Self {
-        Self { r, g, b, a }
-    }
-}
-
-impl Default for Rgba {
-    fn default() -> Self {
-        Self::new(0.0, 0.0, 0.0, 1.0)
-    }
-}
-
-#[derive(Debug, Deserialize, Copy, Clone, PartialEq, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum BackgroundType {
-    Color,
-    Image,
-}
-
-#[derive(Deserialize, Copy, Clone, PartialEq, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum BackgroundImageScale {
-    Stretch,
-    Fill,
-    Fit,
-    Center,
-    Tile,
-}
-
-impl FromStr for Rgba {
-    type Err = String;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let s = s.strip_prefix('#').unwrap_or(s);
-        let argb = match s.len() {
-            6 => {
-                let r =
-                    u8::from_str_radix(&s[0..2], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                let g =
-                    u8::from_str_radix(&s[2..4], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                let b =
-                    u8::from_str_radix(&s[4..6], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                Self { r, g, b, a: 1.0 }
-            }
-            8 => {
-                let r =
-                    u8::from_str_radix(&s[0..2], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                let g =
-                    u8::from_str_radix(&s[2..4], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                let b =
-                    u8::from_str_radix(&s[4..6], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                let a =
-                    u8::from_str_radix(&s[6..8], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
-                Self { r, g, b, a }
-            }
-            _ => return Err("expected RRGGBBAA or RRGGBB format".to_string()),
-        };
-        Ok(argb)
-    }
-}
-
-impl<'de> Deserialize<'de> for Rgba {
-    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(d)?;
-        let argb = Self::from_str(&s).map_err(de::Error::custom)?;
-        Ok(argb)
-    }
-}
-
-#[derive(Debug, Deserialize, Copy, Clone, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum FontSlant {
-    Normal,
-    Italic,
-    Oblique,
-}
-
-impl From<FontSlant> for cairo::FontSlant {
-    fn from(value: FontSlant) -> Self {
-        match value {
-            FontSlant::Normal => Self::Normal,
-            FontSlant::Italic => Self::Italic,
-            FontSlant::Oblique => Self::Oblique,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Copy, Clone, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum FontWeight {
-    Normal,
-    Bold,
-}
-
-impl From<FontWeight> for cairo::FontWeight {
-    fn from(value: FontWeight) -> Self {
-        match value {
-            FontWeight::Normal => Self::Normal,
-            FontWeight::Bold => Self::Bold,
-        }
-    }
-}
 
 pub struct NLockSurface {
     pub created: bool,
@@ -151,9 +35,12 @@ pub struct NLockSurface {
     last_height: Option<u32>,
     physical_width: Option<i32>,
     physical_height: Option<i32>,
-    dpi: Option<f64>,
 
-    pub subpixel: Option<WEnum<wl_output::Subpixel>>,
+    dpi: Option<f64>,
+    subpixel: Option<cairo::SubpixelOrder>,
+
+    renderer: NLockRenderer,
+
     pub ov_surface: Option<wl_surface::WlSurface>,
     pub bg_surface: Option<wl_surface::WlSurface>,
     pub subsurface: Option<wl_subsurface::WlSubsurface>,
@@ -177,6 +64,7 @@ impl NLockSurface {
             physical_width: None,
             physical_height: None,
             dpi: None,
+            renderer: NLockRenderer::default(),
             subpixel: None,
             ov_surface: None,
             bg_surface: None,
@@ -185,30 +73,6 @@ impl NLockSurface {
             lock_surface: None,
             buffers: Vec::new(),
         }
-    }
-
-    fn get_cairo_subpixel_order(&self) -> cairo::SubpixelOrder {
-        if let Some(subpixel) = self.subpixel {
-            match subpixel {
-                WEnum::Value(wl_output::Subpixel::HorizontalRgb) => {
-                    return cairo::SubpixelOrder::Rgb;
-                }
-                WEnum::Value(wl_output::Subpixel::HorizontalBgr) => {
-                    return cairo::SubpixelOrder::Bgr;
-                }
-                WEnum::Value(wl_output::Subpixel::VerticalRgb) => {
-                    return cairo::SubpixelOrder::Vrgb;
-                }
-                WEnum::Value(wl_output::Subpixel::VerticalBgr) => {
-                    return cairo::SubpixelOrder::Vbgr;
-                }
-                _ => {
-                    return cairo::SubpixelOrder::Default;
-                }
-            }
-        }
-
-        cairo::SubpixelOrder::Default
     }
 
     /// Get the **scaled** dimensions of the current output
@@ -287,179 +151,16 @@ impl NLockSurface {
         Ok(())
     }
 
+    pub fn set_subpixel_order(&mut self, order: cairo::SubpixelOrder) {
+        self.subpixel = Some(order);
+        self.renderer.set_subpixel_order(order);
+    }
+
     fn update_last_dimensions(&mut self) -> Result<()> {
         let (width, height) = self.get_dimensions::<u32>()?;
 
         self.last_width = Some(width);
         self.last_height = Some(height);
-
-        Ok(())
-    }
-
-    fn draw_background_image(
-        &self,
-        mode: BackgroundImageScale,
-        bg_image: &cairo::ImageSurface,
-        context: &cairo::Context,
-    ) -> Result<()> {
-        let (buf_width, buf_height) = self.get_dimensions::<f64>()?;
-
-        let width = bg_image.width() as f64;
-        let height = bg_image.height() as f64;
-
-        match mode {
-            BackgroundImageScale::Stretch => {
-                context.scale(buf_width / width, buf_height / height);
-                context.set_source_surface(bg_image, 0.0, 0.0)?;
-            }
-            BackgroundImageScale::Center => {
-                context.set_source_surface(
-                    bg_image,
-                    (buf_width / 2.0 - width / 2.0).floor(),
-                    (buf_height / 2.0 - height / 2.0).floor(),
-                )?;
-            }
-            BackgroundImageScale::Tile => {
-                let pattern = SurfacePattern::create(bg_image);
-                pattern.set_extend(cairo::Extend::Repeat);
-                context.set_source(pattern)?;
-            }
-            BackgroundImageScale::Fit => {
-                let buf_ratio = buf_width / buf_height;
-                let bg_ratio = width / height;
-
-                if buf_ratio > bg_ratio {
-                    let scale = buf_height / height;
-                    context.scale(scale, scale);
-                    context.set_source_surface(
-                        bg_image,
-                        buf_width / 2.0 / scale - width / 2.0,
-                        0.0,
-                    )?;
-                } else {
-                    let scale = buf_width / width;
-                    context.scale(scale, scale);
-                    context.set_source_surface(
-                        bg_image,
-                        0.0,
-                        buf_height / 2.0 / scale - height / 2.0,
-                    )?;
-                }
-            }
-            BackgroundImageScale::Fill => {
-                let buf_ratio = buf_width / buf_height;
-                let bg_ratio = width / height;
-
-                if buf_ratio > bg_ratio {
-                    let scale = buf_width / width;
-                    context.scale(scale, scale);
-                    context.set_source_surface(
-                        bg_image,
-                        0.0,
-                        buf_height / 2.0 / scale - height / 2.0,
-                    )?;
-                } else {
-                    let scale = buf_height / height;
-                    context.scale(scale, scale);
-                    context.set_source_surface(
-                        bg_image,
-                        buf_width / 2.0 / scale - width / 2.0,
-                        0.0,
-                    )?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn render_background(
-        &mut self,
-        config: &NLockConfig,
-        bg_image: Option<&cairo::ImageSurface>,
-        shm: &wl_shm::WlShm,
-        qh: &QueueHandle<NLockState>,
-    ) -> Result<()> {
-        let idx = match self.get_buffer_idx(shm, qh) {
-            Some(i) => i,
-            None => {
-                bail!("Failed to obtain buffer for rendering background");
-            }
-        };
-
-        trace!("got buffer index {} for background", idx);
-
-        let surface = match &self.bg_surface {
-            Some(s) => s,
-            None => {
-                bail!("wl_surface not set when attempting background render");
-            }
-        };
-
-        let buffer = &self.buffers[idx];
-        let context = &buffer.context;
-
-        context.save()?;
-
-        self.reset_cairo_context(context)?;
-
-        match config.general.bg_type {
-            BackgroundType::Color => {
-                context.ext_set_source_rgba(config.colors.bg);
-                context.set_operator(cairo::Operator::Source);
-            }
-            BackgroundType::Image => {
-                let image = bg_image.ok_or(anyhow!("Surface in image mode, but no image set!"))?;
-                self.draw_background_image(config.image.scale, image, context)?;
-            }
-        }
-        context.paint()?;
-        context.restore()?;
-
-        let mut buf_guard = buffer
-            .lock_buffer()
-            .ok_or(anyhow!("Failed to lock buffer {}", idx))?;
-        buf_guard.commit_to(surface, self.output_scale);
-
-        // Avoid rendering the background again
-        self.bg_rendered = true;
-
-        Ok(())
-    }
-
-    fn clear_background(&self, context: &cairo::Context) -> Result<()> {
-        context.save()?;
-        context.set_operator(cairo::Operator::Source);
-        context.set_source_rgba(0.0, 0.0, 0.0, 0.0);
-        context.paint()?;
-        context.restore()?;
-
-        Ok(())
-    }
-
-    fn reset_cairo_context(&self, context: &cairo::Context) -> Result<()> {
-        context.set_antialias(cairo::Antialias::Best);
-        self.clear_background(context)?;
-        context.identity_matrix();
-
-        Ok(())
-    }
-
-    fn configure_cairo_font(&self, config: &NLockConfig, context: &cairo::Context) -> Result<()> {
-        let mut fo = cairo::FontOptions::new()?;
-        fo.set_hint_style(cairo::HintStyle::Full);
-        fo.set_antialias(cairo::Antialias::Subpixel);
-        fo.set_subpixel_order(self.get_cairo_subpixel_order());
-
-        context.set_font_options(&fo);
-        context.select_font_face(
-            &config.font.family,
-            cairo::FontSlant::from(config.font.slant),
-            cairo::FontWeight::from(config.font.weight),
-        );
-
-        let dpi = self.dpi.unwrap_or(DEFAULT_DPI);
-        context.set_font_size((config.font.size / 72.0) * dpi);
 
         Ok(())
     }
@@ -538,6 +239,7 @@ impl NLockSurface {
         .unwrap_or(DEFAULT_DPI);
 
         self.dpi = Some(dpi);
+        self.renderer.set_dpi(dpi);
     }
 
     pub fn create_surface(
@@ -579,39 +281,11 @@ impl NLockSurface {
         }
     }
 
-    fn draw_rounded_rect(context: &cairo::Context, x: f64, y: f64, w: f64, h: f64, r: f64) {
-        context.new_sub_path();
-        context.arc(x + w - r, y + r, r, -90f64.to_radians(), 0f64.to_radians());
-        context.arc(
-            x + w - r,
-            y + h - r,
-            r,
-            0f64.to_radians(),
-            90f64.to_radians(),
-        );
-        context.arc(x + r, y + h - r, r, 90f64.to_radians(), 180f64.to_radians());
-        context.arc(x + r, y + r, r, 180f64.to_radians(), 270f64.to_radians());
-        context.close_path();
-    }
-
-    fn set_frame_border_color(
-        &self,
-        config: &NLockConfig,
-        context: &cairo::Context,
-        auth_state: AuthState,
-    ) {
-        match auth_state {
-            AuthState::Idle => context.ext_set_source_rgba(config.colors.frame_border_idle),
-            AuthState::Success => context.ext_set_source_rgba(config.colors.frame_border_success),
-            AuthState::Fail => context.ext_set_source_rgba(config.colors.frame_border_fail),
-        }
-    }
-
     pub fn render(
         &mut self,
         config: &NLockConfig,
         auth_state: AuthState,
-        password_len: usize,
+        pwd_len: usize,
         bg_image: Option<&cairo::ImageSurface>,
         shm: &wl_shm::WlShm,
         qh: &QueueHandle<NLockState>,
@@ -630,7 +304,7 @@ impl NLockSurface {
         }
 
         // Always render the overlay
-        if let Err(e) = self.render_overlay(config, auth_state, password_len, shm, qh) {
+        if let Err(e) = self.render_overlay(config, auth_state, pwd_len, shm, qh) {
             warn!("Error while rendering overlay: {e}");
         }
 
@@ -640,14 +314,67 @@ impl NLockSurface {
         }
     }
 
+    fn render_background(
+        &mut self,
+        config: &NLockConfig,
+        bg_image: Option<&cairo::ImageSurface>,
+        shm: &wl_shm::WlShm,
+        qh: &QueueHandle<NLockState>,
+    ) -> Result<()> {
+        let (buf_width, buf_height) = self.get_dimensions::<f64>()?;
+
+        let idx = match self.get_buffer_idx(shm, qh) {
+            Some(i) => i,
+            None => {
+                bail!("Failed to obtain buffer for rendering background");
+            }
+        };
+
+        trace!("got buffer index {} for background", idx);
+
+        let surface = match &self.bg_surface {
+            Some(s) => s,
+            None => {
+                bail!("wl_surface not set when attempting background render");
+            }
+        };
+
+        let buffer = &self.buffers[idx];
+        let context = &buffer.context;
+
+        context.save()?;
+        self.renderer.render_background(
+            config,
+            NLockRenderBackgroundArgs {
+                buf_height,
+                buf_width,
+                context,
+                image: bg_image,
+            },
+        )?;
+        context.restore()?;
+
+        let mut buf_guard = buffer
+            .lock_buffer()
+            .ok_or(anyhow!("Failed to lock buffer {}", idx))?;
+        buf_guard.commit_to(surface, self.output_scale);
+
+        // Avoid rendering the background again
+        self.bg_rendered = true;
+
+        Ok(())
+    }
+
     fn render_overlay(
         &mut self,
         config: &NLockConfig,
         auth_state: AuthState,
-        password_len: usize,
+        pwd_len: usize,
         shm: &wl_shm::WlShm,
         qh: &QueueHandle<NLockState>,
     ) -> Result<()> {
+        let (buf_width, buf_height) = self.get_dimensions::<f64>()?;
+
         let idx = match self.get_buffer_idx(shm, qh) {
             Some(i) => i,
             None => {
@@ -676,7 +403,16 @@ impl NLockSurface {
 
         // Save context to ensure transformations don't leak
         context.save()?;
-        self.draw_overlay(config, auth_state, password_len, context)?;
+        self.renderer.render_overlay(
+            config,
+            NLockRenderOverlayArgs {
+                auth_state,
+                buf_height,
+                buf_width,
+                context,
+                pwd_len,
+            },
+        )?;
         context.restore()?;
 
         // Ensure subsurface position is always set to 0,0
@@ -686,107 +422,6 @@ impl NLockSurface {
             .lock_buffer()
             .ok_or(anyhow!("Failed to lock buffer {}", idx))?;
         buf_guard.commit_to(surface, self.output_scale);
-
-        Ok(())
-    }
-
-    fn draw_overlay(
-        &self,
-        config: &NLockConfig,
-        auth_state: AuthState,
-        password_len: usize,
-        context: &cairo::Context,
-    ) -> Result<()> {
-        // These dimensions are already scaled
-        let (width, height) = self.get_dimensions::<f64>()?;
-
-        // Reset the context for fresh rendering
-        self.reset_cairo_context(context)?;
-
-        // Draw border colour
-        context.save()?;
-        self.set_frame_border_color(config, context, auth_state);
-        context.set_line_width(config.frame.border);
-
-        let frame_offset = config.frame.border / 2.0;
-        let frame_w = width - (frame_offset * 2.0);
-        let frame_h = height - (frame_offset * 2.0);
-
-        Self::draw_rounded_rect(
-            context,
-            frame_offset,
-            frame_offset,
-            frame_w,
-            frame_h,
-            config.frame.radius,
-        );
-        context.stroke()?;
-        context.restore()?;
-
-        // Skip drawing input box if the password is empty and config flag set
-        if password_len == 0 && config.input.hide_when_empty {
-            return Ok(());
-        }
-
-        self.configure_cairo_font(config, context)?;
-
-        let fe = context.font_extents()?;
-
-        let padding_x = config.input.padding_x * width;
-        let padding_y = config.input.padding_y * height;
-
-        // Calculate text extents here, so input box width can be determined
-        let text = config.input.mask_char.repeat(password_len);
-        let text_ext = context.text_extents(text.as_str())?;
-
-        let mut inner_w = width * config.input.width;
-
-        if config.input.fit_to_content {
-            // Cap computed width to specified width
-            inner_w = text_ext.width().min(inner_w);
-        }
-
-        let inner_h = fe.height();
-        let inner_x = (width - inner_w) / 2.0;
-        let inner_y = (height - inner_h) / 2.0;
-
-        let outer_h = inner_h + (padding_y * 2.0) + config.input.border;
-        let outer_w = inner_w + (padding_x * 2.0) + config.input.border;
-        let outer_x = (width - outer_w) / 2.0;
-        let outer_y = (height - outer_h) / 2.0;
-
-        context.save()?;
-
-        // Draw the outer rectangle, including padding
-        // Outer rectangle should have rounded corners
-        Self::draw_rounded_rect(
-            context,
-            outer_x,
-            outer_y,
-            outer_w,
-            outer_h,
-            config.input.radius * outer_h, // radius is relative, Cairo requires absolute
-        );
-        context.ext_set_source_rgba(config.colors.input_bg);
-        context.fill_preserve()?;
-        context.ext_set_source_rgba(config.colors.input_border);
-        context.set_line_width(config.input.border);
-        context.stroke_preserve()?;
-        context.clip();
-
-        // Clip text to the inner rectangle
-        context.rectangle(inner_x, inner_y, inner_w, inner_h);
-        context.clip();
-
-        let text_x = inner_x + (inner_w - text_ext.width()) / 2.0 - text_ext.x_bearing();
-        let text_y = inner_y + (inner_h - fe.descent()) / 2.0 + fe.ascent() / 2.0;
-
-        // Actually draw the text
-        context.ext_set_source_rgba(config.colors.text);
-        context.move_to(text_x, text_y);
-        context.show_text(text.as_str())?;
-
-        context.restore()?;
 
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
+use std::{os::fd::OwnedFd, str::FromStr};
+
+use clap::ValueEnum;
 use nix::{
     fcntl::OFlag,
     libc,
@@ -10,8 +13,122 @@ use nix::{
     },
     unistd::getpid,
 };
-use std::os::fd::OwnedFd;
+use serde::{Deserialize, de};
 use tracing::debug;
+
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum BackgroundType {
+    Color,
+    Image,
+}
+
+#[derive(Deserialize, Copy, Clone, PartialEq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum BackgroundImageScale {
+    Stretch,
+    Fill,
+    Fit,
+    Center,
+    Tile,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Rgba {
+    pub r: f64,
+    pub g: f64,
+    pub b: f64,
+    pub a: f64,
+}
+
+impl Rgba {
+    pub fn new(r: f64, g: f64, b: f64, a: f64) -> Self {
+        Self { r, g, b, a }
+    }
+}
+
+impl Default for Rgba {
+    fn default() -> Self {
+        Self::new(0.0, 0.0, 0.0, 1.0)
+    }
+}
+
+impl FromStr for Rgba {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let s = s.strip_prefix('#').unwrap_or(s);
+        let argb = match s.len() {
+            6 => {
+                let r =
+                    u8::from_str_radix(&s[0..2], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                let g =
+                    u8::from_str_radix(&s[2..4], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                let b =
+                    u8::from_str_radix(&s[4..6], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                Self { r, g, b, a: 1.0 }
+            }
+            8 => {
+                let r =
+                    u8::from_str_radix(&s[0..2], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                let g =
+                    u8::from_str_radix(&s[2..4], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                let b =
+                    u8::from_str_radix(&s[4..6], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                let a =
+                    u8::from_str_radix(&s[6..8], 16).map_err(|e| e.to_string())? as f64 / 255.0f64;
+                Self { r, g, b, a }
+            }
+            _ => return Err("expected RRGGBBAA or RRGGBB format".to_string()),
+        };
+        Ok(argb)
+    }
+}
+
+impl<'de> Deserialize<'de> for Rgba {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        let argb = Self::from_str(&s).map_err(de::Error::custom)?;
+        Ok(argb)
+    }
+}
+
+#[derive(Debug, Deserialize, Copy, Clone, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum FontSlant {
+    Normal,
+    Italic,
+    Oblique,
+}
+
+impl From<FontSlant> for cairo::FontSlant {
+    fn from(value: FontSlant) -> Self {
+        match value {
+            FontSlant::Normal => Self::Normal,
+            FontSlant::Italic => Self::Italic,
+            FontSlant::Oblique => Self::Oblique,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Copy, Clone, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum FontWeight {
+    Normal,
+    Bold,
+}
+
+impl From<FontWeight> for cairo::FontWeight {
+    fn from(value: FontWeight) -> Self {
+        match value {
+            FontWeight::Normal => Self::Normal,
+            FontWeight::Bold => Self::Bold,
+        }
+    }
+}
 
 pub fn open_shm() -> Option<OwnedFd> {
     let mut retries = 100;


### PR DESCRIPTION
- move renderer to new `NLockRenderer` struct
- move rendering enums into `util` module
- clean up `surface` module