### PR TITLE
fix: handle multi-byte unicode characters in password string

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -176,7 +176,7 @@ impl NLockState {
                 self.surfaces[i].render(
                     &self.config,
                     auth_state,
-                    self.password.len(),
+                    self.password.chars().count(),
                     self.background_image.as_ref(),
                     shm,
                     qh,

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -478,7 +478,7 @@ impl Dispatch<ext_session_lock_surface_v1::ExtSessionLockSurfaceV1, usize> for N
             surface.render(
                 &state.config,
                 auth_state,
-                state.password.len(),
+                state.password.chars().count(),
                 state.background_image.as_ref(),
                 shm,
                 qh,


### PR DESCRIPTION
- calculate password length in codepoints, not bytes, which produces incorrect lengths when multi-byte unicode chars are entered.

closes #48