### PR TITLE
refactor(args): use `clap-derive` for argument parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.100"
 atomic_enum = "0.3.0"
 cairo-rs = { version = "0.21.2", features = [ "png" ] }
 chrono = "0.4.42"
-clap = { version = "4.5.53", features = [ "derive" ] }
+clap = { version = "4.5.53", features = ["derive"] }
 clap_complete = "4.5.64"
 config = "0.15.18"
 dirs = "6.0.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 
 use clap::{
-    Arg, ArgAction, ArgMatches, Command, ValueEnum,
+    Command, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
     builder::{
-        EnumValueParser, Styles,
+        Styles,
         styling::{AnsiColor, Effects},
     },
 };
@@ -38,243 +35,114 @@ impl LogLevel {
     }
 }
 
-pub trait LoadArgMatches {
-    fn load_arg_matches(matches: &ArgMatches) -> Self;
-}
-
-macro_rules! args_get_value {
-    ($matches:expr, $obj:ty, $name:expr) => {
-        $matches.get_one::<$obj>($name).cloned()
-    };
-}
-
+/// Customisable, minimalist screen locker for Wayland
+#[derive(Parser, Debug)]
 pub struct NLockArgs {
+    #[command(subcommand)]
+    pub subcommand: Option<NLockSubcommands>,
+
+    /// Log verbosity
+    #[arg(short, long, default_value = "info")]
     pub log_level: LogLevel,
+    /// Configuration file path
+    #[arg(short, long)]
     pub config_file: Option<String>,
-    pub colors: NLockArgsColors,
-    pub font: NLockArgsFont,
-    pub input: NLockArgsInput,
-    pub frame: NLockArgsFrame,
-    pub general: NLockArgsGeneral,
-    pub image: NLockArgsImage,
-}
 
-impl LoadArgMatches for NLockArgs {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let log_level = matches
-            .get_one::<LogLevel>("log_level")
-            .cloned()
-            .unwrap_or(LogLevel::Info);
-        let config_file = matches.get_one::<String>("config_file").cloned();
+    /// Sets the background color
+    #[arg(long)]
+    pub bg_color: Option<Rgba>,
+    /// Sets the text color
+    #[arg(long)]
+    pub text_color: Option<Rgba>,
+    /// Sets the input background color
+    #[arg(long)]
+    pub input_bg_color: Option<Rgba>,
+    /// Sets the input border color
+    #[arg(long)]
+    pub input_border_color: Option<Rgba>,
+    /// Sets the idle frame border color
+    #[arg(long)]
+    pub frame_border_idle_color: Option<Rgba>,
+    /// Sets the success frame border color
+    #[arg(long)]
+    pub frame_border_success_color: Option<Rgba>,
+    /// Sets the fail frame border color
+    #[arg(long)]
+    pub frame_border_fail_color: Option<Rgba>,
 
-        Self {
-            log_level,
-            config_file,
-            colors: NLockArgsColors::load_arg_matches(matches),
-            font: NLockArgsFont::load_arg_matches(matches),
-            input: NLockArgsInput::load_arg_matches(matches),
-            frame: NLockArgsFrame::load_arg_matches(matches),
-            general: NLockArgsGeneral::load_arg_matches(matches),
-            image: NLockArgsImage::load_arg_matches(matches),
-        }
-    }
-}
-
-macro_rules! color_arg {
-    ($id:expr, $long:expr, $help:expr) => {
-        Arg::new($id)
-            .help($help)
-            .long($long)
-            .value_name("COLOR")
-            .value_parser(Rgba::from_str)
-    };
-}
-
-macro_rules! enum_arg {
-    ($id:expr, $long:expr, $help:expr, $val:expr, $t:ty) => {
-        Arg::new($id)
-            .help($help)
-            .long($long)
-            .value_name($val)
-            .value_parser(EnumValueParser::<$t>::new())
-    };
-}
-
-macro_rules! string_arg {
-    ($id:expr, $long:expr, $help:expr) => {
-        Arg::new($id).help($help).long($long).value_name("STRING")
-    };
-}
-
-macro_rules! path_arg {
-    ($id:expr, $long:expr, $help:expr) => {
-        Arg::new($id)
-            .help($help)
-            .long($long)
-            .value_name("PATH")
-            .value_parser(PathBuf::from_str)
-    };
-}
-
-macro_rules! f64_arg {
-    ($id:expr, $long:expr, $help:expr) => {
-        Arg::new($id)
-            .help($help)
-            .long($long)
-            .value_name("FLOAT")
-            .value_parser(f64::from_str)
-    };
-}
-
-macro_rules! bool_arg {
-    ($id:expr, $long:expr, $help:expr) => {
-        Arg::new($id)
-            .help($help)
-            .long($long)
-            .value_name("BOOL")
-            .value_parser(bool::from_str)
-    };
-}
-
-pub struct NLockArgsColors {
-    pub bg: Option<Rgba>,
-    pub text: Option<Rgba>,
-    pub input_bg: Option<Rgba>,
-    pub input_border: Option<Rgba>,
-    pub frame_border_idle: Option<Rgba>,
-    pub frame_border_success: Option<Rgba>,
-    pub frame_border_fail: Option<Rgba>,
-}
-
-impl LoadArgMatches for NLockArgsColors {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let bg = args_get_value!(matches, Rgba, "bg_color");
-        let text = args_get_value!(matches, Rgba, "text_color");
-        let input_bg = args_get_value!(matches, Rgba, "input_bg_color");
-        let input_border = args_get_value!(matches, Rgba, "input_border_color");
-        let frame_border_idle = args_get_value!(matches, Rgba, "frame_border_idle_color");
-        let frame_border_success = args_get_value!(matches, Rgba, "frame_border_success_color");
-        let frame_border_fail = args_get_value!(matches, Rgba, "frame_border_fail_color");
-
-        Self {
-            bg,
-            text,
-            input_bg,
-            input_border,
-            frame_border_idle,
-            frame_border_success,
-            frame_border_fail,
-        }
-    }
-}
-
-pub struct NLockArgsFont {
-    pub size: Option<f64>,
-    pub family: Option<String>,
-    pub slant: Option<FontSlant>,
-    pub weight: Option<FontWeight>,
+    /// Sets the font size, in points
+    #[arg(long)]
+    pub font_size: Option<f64>,
+    /// Sets the font family
+    #[arg(long)]
+    pub font_family: Option<String>,
+    /// Sets the font slant
+    #[arg(long)]
+    pub font_slant: Option<FontSlant>,
+    /// Sets the font weight
+    #[arg(long)]
+    pub font_weight: Option<FontWeight>,
+    /// Scale font size by display output DPI
+    #[arg(long)]
     pub use_dpi_scaling: Option<bool>,
-}
 
-impl LoadArgMatches for NLockArgsFont {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let size = args_get_value!(matches, f64, "font_size");
-        let family = args_get_value!(matches, String, "font_family");
-        let slant = args_get_value!(matches, FontSlant, "font_slant");
-        let weight = args_get_value!(matches, FontWeight, "font_weight");
-        let use_dpi_scaling = args_get_value!(matches, bool, "use_dpi_scaling");
-
-        Self {
-            size,
-            family,
-            slant,
-            weight,
-            use_dpi_scaling,
-        }
-    }
-}
-
-pub struct NLockArgsInput {
+    /// Sets the mask character for the input box
+    #[arg(long)]
     pub mask_char: Option<String>,
-    pub width: Option<f64>,
-    pub padding_x: Option<f64>,
-    pub padding_y: Option<f64>,
-    pub radius: Option<f64>,
-    pub border: Option<f64>,
+    /// Sets the relative width of the input box
+    #[arg(long)]
+    pub input_width: Option<f64>,
+    /// Sets the relative horizontal padding of the input box
+    #[arg(long)]
+    pub input_padding_x: Option<f64>,
+    /// Sets the relative vertical padding of the input box
+    #[arg(long)]
+    pub input_padding_y: Option<f64>,
+    /// Sets the relative border radius of the input box
+    #[arg(long)]
+    pub input_radius: Option<f64>,
+    /// Sets tne border width of the input box
+    #[arg(long)]
+    pub input_border: Option<f64>,
+    /// Hide the input box when empty
+    #[arg(long)]
     pub hide_when_empty: Option<bool>,
+    /// Resize the input box to fit the entered password
+    #[arg(long)]
     pub fit_to_content: Option<bool>,
-}
 
-impl LoadArgMatches for NLockArgsInput {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let mask_char = args_get_value!(matches, String, "mask_char");
-        let width = args_get_value!(matches, f64, "input_width");
-        let padding_x = args_get_value!(matches, f64, "input_padding_x");
-        let padding_y = args_get_value!(matches, f64, "input_padding_y");
-        let radius = args_get_value!(matches, f64, "input_radius");
-        let border = args_get_value!(matches, f64, "input_border");
-        let hide_when_empty = args_get_value!(matches, bool, "input_hide_when_empty");
-        let fit_to_content = args_get_value!(matches, bool, "input_fit_to_content");
+    /// Sets the border radius of the frame
+    #[arg(long)]
+    pub frame_radius: Option<f64>,
+    /// Sets the border width of the frame
+    #[arg(long)]
+    pub frame_border: Option<f64>,
 
-        Self {
-            mask_char,
-            width,
-            padding_x,
-            padding_y,
-            radius,
-            border,
-            hide_when_empty,
-            fit_to_content,
-        }
-    }
-}
-
-pub struct NLockArgsFrame {
-    pub border: Option<f64>,
-    pub radius: Option<f64>,
-}
-
-impl LoadArgMatches for NLockArgsFrame {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let border = args_get_value!(matches, f64, "frame_border");
-        let radius = args_get_value!(matches, f64, "frame_radius");
-
-        Self { border, radius }
-    }
-}
-
-pub struct NLockArgsGeneral {
+    /// Validate empty passwords
+    #[arg(long)]
     pub pwd_allow_empty: Option<bool>,
+    /// Hide the mouse cursor
+    #[arg(long)]
     pub hide_cursor: Option<bool>,
+
+    /// Sets the background type
+    #[arg(long)]
     pub bg_type: Option<BackgroundType>,
+    /// Path to a background image
+    #[arg(long)]
+    pub image_path: Option<PathBuf>,
+    /// Sets the image scaling mode
+    #[arg(long)]
+    pub image_scale: Option<BackgroundImageScale>,
 }
 
-impl LoadArgMatches for NLockArgsGeneral {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let pwd_allow_empty = args_get_value!(matches, bool, "pwd_allow_empty");
-        let hide_cursor = args_get_value!(matches, bool, "hide_cursor");
-        let bg_type = args_get_value!(matches, BackgroundType, "bg_type");
-
-        Self {
-            pwd_allow_empty,
-            hide_cursor,
-            bg_type,
-        }
-    }
-}
-
-pub struct NLockArgsImage {
-    pub path: Option<PathBuf>,
-    pub scale: Option<BackgroundImageScale>,
-}
-
-impl LoadArgMatches for NLockArgsImage {
-    fn load_arg_matches(matches: &ArgMatches) -> Self {
-        let path = args_get_value!(matches, PathBuf, "image_path");
-        let scale = args_get_value!(matches, BackgroundImageScale, "image_scale");
-
-        Self { path, scale }
-    }
+#[derive(Subcommand, Debug)]
+pub enum NLockSubcommands {
+    /// Generate shell completions for nlock
+    Completions {
+        /// Shell to generate completions for
+        shell: Option<String>,
+    },
 }
 
 fn styles() -> Styles {
@@ -288,190 +156,17 @@ fn styles() -> Styles {
 }
 
 fn build_cli() -> Command {
-    Command::new("nlock")
-        .about("Customisable, minimalist screen locker for Wayland")
-        .version(env!("CARGO_PKG_VERSION"))
-        .styles(styles())
-        .subcommand(
-            Command::new("completions")
-                .about("Generate shell completions for nlock")
-                .arg(
-                    Arg::new("shell")
-                        .help("Shell to generate completions for")
-                        .value_name("SHELL")
-                        .action(ArgAction::Set),
-                ),
-        )
-        .arg(
-            Arg::new("log_level")
-                .help("Log level verbosity")
-                .short('l')
-                .long("log-level")
-                .value_name("LOG LEVEL")
-                .value_parser(EnumValueParser::<LogLevel>::new())
-                .default_value("info"),
-        )
-        .arg(
-            Arg::new("config_file")
-                .help("Path to the configuration file")
-                .short('c')
-                .long("config-file")
-                .value_name("CONFIG FILE"),
-        )
-        .arg(color_arg!(
-            "bg_color",
-            "bg-color",
-            "Sets the background color"
-        ))
-        .arg(color_arg!(
-            "text_color",
-            "text-color",
-            "Sets the text color"
-        ))
-        .arg(color_arg!(
-            "input_bg_color",
-            "input-bg-color",
-            "Sets the input background color"
-        ))
-        .arg(color_arg!(
-            "input_border_color",
-            "input-border-color",
-            "Sets the input border color"
-        ))
-        .arg(color_arg!(
-            "frame_border_idle_color",
-            "frame-border-idle-color",
-            "Sets the idle frame border color"
-        ))
-        .arg(color_arg!(
-            "frame_border_success_color",
-            "frame-border-success-color",
-            "Sets the success frame border color"
-        ))
-        .arg(color_arg!(
-            "frame_border_fail_color",
-            "frame-border-fail-color",
-            "Sets the fail frame border color"
-        ))
-        .arg(f64_arg!(
-            "font_size",
-            "font-size",
-            "Sets the font size, in points"
-        ))
-        .arg(string_arg!(
-            "font_family",
-            "font-family",
-            "Sets the font family"
-        ))
-        .arg(enum_arg!(
-            "font_slant",
-            "font-slant",
-            "Sets the font slant",
-            "SLANT",
-            FontSlant
-        ))
-        .arg(enum_arg!(
-            "font_weight",
-            "font-weight",
-            "Sets the font weight",
-            "WEIGHT",
-            FontWeight
-        ))
-        .arg(bool_arg!(
-            "use_dpi_scaling",
-            "use-dpi-scaling",
-            "Scale font size based on output DPI"
-        ))
-        .arg(string_arg!(
-            "mask_char",
-            "mask-char",
-            "Sets the mask character for the input box"
-        ))
-        .arg(f64_arg!(
-            "input_width",
-            "input-width",
-            "Sets the relative width of the input box"
-        ))
-        .arg(f64_arg!(
-            "input_padding_x",
-            "input-padding_x",
-            "Sets the relative horizontal padding of the input box"
-        ))
-        .arg(f64_arg!(
-            "input_padding_y",
-            "input-padding_y",
-            "Sets the relative vertical padding of the input box"
-        ))
-        .arg(f64_arg!(
-            "input_radius",
-            "input-radius",
-            "Sets the relative border radius of the input box"
-        ))
-        .arg(f64_arg!(
-            "input_border",
-            "input-border",
-            "Sets the border width of the input box"
-        ))
-        .arg(bool_arg!(
-            "input_hide_when_empty",
-            "input-hide-when-empty",
-            "Hide the input box when empty"
-        ))
-        .arg(bool_arg!(
-            "input_fit_to_content",
-            "input-fit-to-content",
-            "Resize the input box to fit password"
-        ))
-        .arg(f64_arg!(
-            "frame_radius",
-            "frame-radius",
-            "Sets the border radius of the frame"
-        ))
-        .arg(f64_arg!(
-            "frame_border",
-            "frame-border",
-            "Sets the border width of the frame"
-        ))
-        .arg(bool_arg!(
-            "pwd_allow_empty",
-            "allow-empty-password",
-            "Validate empty passwords"
-        ))
-        .arg(bool_arg!(
-            "hide_cursor",
-            "hide-cursor",
-            "Hide the mouse cursor"
-        ))
-        .arg(enum_arg!(
-            "bg_type",
-            "bg-type",
-            "Sets the background type",
-            "BACKGROUND TYPE",
-            BackgroundType
-        ))
-        .arg(path_arg!(
-            "image_path",
-            "image-path",
-            "Path to background image"
-        ))
-        .arg(enum_arg!(
-            "image_scale",
-            "image-scale",
-            "Sets the image scaling mode",
-            "SCALE MODE",
-            BackgroundImageScale
-        ))
+    NLockArgs::command().styles(styles())
 }
 
 pub fn run_cli() -> NLockArgs {
-    let cli = build_cli();
-    let args = cli.get_matches();
+    let mut matches = build_cli().get_matches();
+    let args = NLockArgs::from_arg_matches_mut(&mut matches).unwrap();
 
-    if let Some(("completions", args)) = args.subcommand() {
-        let shell_arg = args.get_one::<String>("shell");
-
-        let shell = if let Some(shell_arg) = shell_arg {
-            Shell::from_shell_path(Path::new(shell_arg))
+    // Shell completion subcommand
+    if let Some(NLockSubcommands::Completions { shell }) = args.subcommand {
+        let shell = if let Some(shell) = shell {
+            Shell::from_shell_path(Path::new(&shell))
         } else {
             Shell::from_env()
         };
@@ -486,7 +181,7 @@ pub fn run_cli() -> NLockArgs {
 
         // Don't continue running after generation
         std::process::exit(0);
-    } else {
-        NLockArgs::load_arg_matches(&args)
     }
+
+    args
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,13 +129,13 @@ impl Default for NLockConfigColors {
 
 impl LoadArgOverrides for NLockConfigColors {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some!(self.bg, args.colors.bg);
-        set_if_some!(self.text, args.colors.text);
-        set_if_some!(self.input_bg, args.colors.input_bg);
-        set_if_some!(self.input_border, args.colors.input_border);
-        set_if_some!(self.frame_border_idle, args.colors.frame_border_idle);
-        set_if_some!(self.frame_border_success, args.colors.frame_border_success);
-        set_if_some!(self.frame_border_fail, args.colors.frame_border_fail);
+        set_if_some!(self.bg, args.bg_color);
+        set_if_some!(self.text, args.text_color);
+        set_if_some!(self.input_bg, args.input_bg_color);
+        set_if_some!(self.input_border, args.input_border_color);
+        set_if_some!(self.frame_border_idle, args.frame_border_idle_color);
+        set_if_some!(self.frame_border_success, args.frame_border_success_color);
+        set_if_some!(self.frame_border_fail, args.frame_border_fail_color);
     }
 }
 
@@ -200,11 +200,11 @@ impl Default for NLockConfigFont {
 
 impl LoadArgOverrides for NLockConfigFont {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some!(self.size, args.font.size);
-        set_if_some_string!(self.family, &args.font.family);
-        set_if_some!(self.slant, args.font.slant);
-        set_if_some!(self.weight, args.font.weight);
-        set_if_some!(self.use_dpi_scaling, args.font.use_dpi_scaling);
+        set_if_some!(self.size, args.font_size);
+        set_if_some_string!(self.family, &args.font_family);
+        set_if_some!(self.slant, args.font_slant);
+        set_if_some!(self.weight, args.font_weight);
+        set_if_some!(self.use_dpi_scaling, args.use_dpi_scaling);
     }
 }
 
@@ -273,14 +273,14 @@ impl Default for NLockConfigInput {
 
 impl LoadArgOverrides for NLockConfigInput {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some_string!(self.mask_char, &args.input.mask_char);
-        set_if_some!(self.width, args.input.width);
-        set_if_some!(self.padding_x, args.input.padding_x);
-        set_if_some!(self.padding_y, args.input.padding_y);
-        set_if_some!(self.radius, args.input.radius);
-        set_if_some!(self.border, args.input.border);
-        set_if_some!(self.hide_when_empty, args.input.hide_when_empty);
-        set_if_some!(self.fit_to_content, args.input.fit_to_content);
+        set_if_some_string!(self.mask_char, &args.mask_char);
+        set_if_some!(self.width, args.input_width);
+        set_if_some!(self.padding_x, args.input_padding_x);
+        set_if_some!(self.padding_y, args.input_padding_y);
+        set_if_some!(self.radius, args.input_radius);
+        set_if_some!(self.border, args.input_border);
+        set_if_some!(self.hide_when_empty, args.hide_when_empty);
+        set_if_some!(self.fit_to_content, args.fit_to_content);
     }
 }
 
@@ -333,8 +333,8 @@ impl Default for NLockConfigFrame {
 
 impl LoadArgOverrides for NLockConfigFrame {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some!(self.border, args.frame.border);
-        set_if_some!(self.radius, args.frame.radius);
+        set_if_some!(self.border, args.frame_border);
+        set_if_some!(self.radius, args.frame_radius);
     }
 }
 
@@ -371,9 +371,9 @@ impl Default for NLockConfigGeneral {
 
 impl LoadArgOverrides for NLockConfigGeneral {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some!(self.pwd_allow_empty, args.general.pwd_allow_empty);
-        set_if_some!(self.hide_cursor, args.general.hide_cursor);
-        set_if_some!(self.bg_type, args.general.bg_type);
+        set_if_some!(self.pwd_allow_empty, args.pwd_allow_empty);
+        set_if_some!(self.hide_cursor, args.hide_cursor);
+        set_if_some!(self.bg_type, args.bg_type);
     }
 }
 
@@ -410,8 +410,8 @@ impl Default for NLockConfigImage {
 
 impl LoadArgOverrides for NLockConfigImage {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
-        set_if_some_path!(self.path, &args.image.path);
-        set_if_some!(self.scale, args.image.scale);
+        set_if_some_path!(self.path, &args.image_path);
+        set_if_some!(self.scale, args.image_scale);
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ pub enum BackgroundType {
     Image,
 }
 
-#[derive(Deserialize, Copy, Clone, PartialEq, ValueEnum)]
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BackgroundImageScale {
     Stretch,


### PR DESCRIPTION
- use `clap-derive` to define args via structs, much simpler than the builder.