### PR TITLE
refactor(util): move `LogLevel` enum into `util` module

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::{
-    Command, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+    Command, CommandFactory, FromArgMatches, Parser, Subcommand,
     builder::{
         Styles,
         styling::{AnsiColor, Effects},
@@ -12,28 +12,7 @@ use clap::{
 };
 use clap_complete::{Shell, aot::generate as generate_completions};
 
-use crate::util::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, Rgba};
-
-#[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum LogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Error,
-}
-
-impl LogLevel {
-    pub fn to_level(self) -> tracing::Level {
-        match self {
-            Self::Trace => tracing::Level::TRACE,
-            Self::Debug => tracing::Level::DEBUG,
-            Self::Info => tracing::Level::INFO,
-            Self::Warn => tracing::Level::WARN,
-            Self::Error => tracing::Level::ERROR,
-        }
-    }
-}
+use crate::util::{BackgroundImageScale, BackgroundType, FontSlant, FontWeight, LogLevel, Rgba};
 
 /// Customisable, minimalist screen locker for Wayland
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::uptime())
-        .with_max_level(args.log_level.to_level())
+        .with_max_level(args.log_level)
         .init();
 
     let now = chrono::Local::now();

--- a/src/util.rs
+++ b/src/util.rs
@@ -134,6 +134,27 @@ impl From<FontWeight> for cairo::FontWeight {
     }
 }
 
+#[derive(Debug, Copy, Clone, ValueEnum)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<LogLevel> for tracing::level_filters::LevelFilter {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Trace => Self::TRACE,
+            LogLevel::Debug => Self::DEBUG,
+            LogLevel::Info => Self::INFO,
+            LogLevel::Warn => Self::WARN,
+            LogLevel::Error => Self::ERROR,
+        }
+    }
+}
+
 pub fn open_shm() -> Option<OwnedFd> {
     let mut retries = 100;
 


### PR DESCRIPTION
- move `LogLevel` to `util`, with other arg-related enums
- impl `From<LogLevel>` on `tracing::level_filters::LevelFilter` to simplify conversion.