### PR TITLE
feat: add support for freebsd targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,9 +900,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.100"
 atomic_enum = "0.3.0"
-cairo-rs = { version = "0.22.0", features = [ "png" ] }
+cairo-rs = { version = "0.22.0", features = ["png"] }
 chrono = "0.4.42"
 clap = { version = "4.5.53", features = ["derive"] }
 clap_complete = "4.5.64"
 config = "0.15.18"
 dirs = "6.0.0"
 gdk-pixbuf = "0.21.5"
-mio = { version = "1.1.1", features = [ "os-ext", "os-poll" ] }
-nix = { version = "0.30.1", features = [ "event", "fs", "mman", "process", "time" ] }
+mio = { version = "1.1.1", features = ["os-ext", "os-poll"] }
+nix = { version = "0.31.3", features = ["event", "fs", "mman", "process", "time"] }
 pam-rs = "0.9.5"
 pango = "0.22.0"
 pangocairo = "0.22.0"
@@ -23,7 +23,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 uzers = "0.12.1"
 wayland-client = "0.31.11"
-wayland-protocols = { version = "0.32.9", features = [ "client", "staging" ] }
+wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
 xkbcommon = "0.9.0"
 zeroize = "1.8.2"
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -37,7 +37,8 @@ The following correspond directly to configuration options. See
 - `--fit-to-content <BOOL>`, resize the input box to fit password
 - `--frame-radius <FLOAT>`, sets the border radius of the frame
 - `--frame-border <FLOAT>`, sets the border width of the frame
-- `--allow-empty-password <BOOL>`, validate empty passwords
+- `--allow-empty-password <BOOL>`, validate empty passwords, this option is
+    only supported on Linux targets
 - `--hide-cursor <BOOL>`, hide the mouse cursor
 - `--bg-type <BACKGROUND TYPE>`, sets the background type
 - `--image-path <PATH>`, path to a background image

--- a/examples/default.toml
+++ b/examples/default.toml
@@ -2,9 +2,10 @@
 
 # General configuration options
 [general]
-allowEmptyPassword = false      # allow a blank password to be validated
 hideCursor = true               # hide the mouse cursor
 backgroundType = "color"        # background type "color", or "image"
+# this option is only supported on Linux targets
+allowEmptyPassword = false      # allow a blank password to be validated
 
 # Colors section configures, well, colors.
 [colors]

--- a/src/args.rs
+++ b/src/args.rs
@@ -101,6 +101,7 @@ pub struct NLockArgs {
 
     /// Validate empty passwords
     #[arg(long)]
+    #[cfg(target_os = "linux")]
     pub pwd_allow_empty: Option<bool>,
     /// Hide the mouse cursor
     #[arg(long)]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -40,24 +40,31 @@ pub enum AuthState {
 }
 
 pub struct AuthConfig {
+    #[cfg(target_os = "linux")]
     pub allow_empty: bool,
 }
 
 impl AuthConfig {
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     pub fn new(config: &NLockConfig) -> Self {
         Self {
+            #[cfg(target_os = "linux")]
             allow_empty: config.general.pwd_allow_empty,
         }
     }
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
 fn authenticate(config: &AuthConfig, username: &str, password: Zeroizing<String>) -> Result<()> {
     let mut client = Client::with_password("nlock")?;
     client
         .conversation_mut()
         .set_credentials(username, password.as_str());
 
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut flags = PamFlag::None;
+
+    #[cfg(target_os = "linux")]
     if !config.allow_empty {
         flags = PamFlag::Disallow_Null_AuthTok;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,6 +349,7 @@ fn default_frame_radius() -> f64 {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NLockConfigGeneral {
+    #[cfg(target_os = "linux")]
     #[serde(default = "default_pwd_allow_empty", rename = "allowEmptyPassword")]
     pub pwd_allow_empty: bool,
 
@@ -362,6 +363,7 @@ pub struct NLockConfigGeneral {
 impl Default for NLockConfigGeneral {
     fn default() -> Self {
         Self {
+            #[cfg(target_os = "linux")]
             pwd_allow_empty: default_pwd_allow_empty(),
             hide_cursor: default_hide_cursor(),
             bg_type: default_bg_type(),
@@ -371,12 +373,14 @@ impl Default for NLockConfigGeneral {
 
 impl LoadArgOverrides for NLockConfigGeneral {
     fn load_arg_overrides(&mut self, args: &NLockArgs) {
+        #[cfg(target_os = "linux")]
         set_if_some!(self.pwd_allow_empty, args.pwd_allow_empty);
         set_if_some!(self.hide_cursor, args.hide_cursor);
         set_if_some!(self.bg_type, args.bg_type);
     }
 }
 
+#[cfg(target_os = "linux")]
 fn default_pwd_allow_empty() -> bool {
     false
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, atomic::Ordering};
 use anyhow::{Result, bail};
 
 #[cfg_attr(debug_assertions, allow(unused_imports))]
+#[cfg(target_os = "linux")]
 use nix::sys::prctl;
 
 use tracing::{debug, error, warn};
@@ -35,6 +36,7 @@ fn start(config: NLockConfig) -> Result<()> {
     // Prevent ptrace from attaching to nlock
     // Only do this in release config
     #[cfg(not(debug_assertions))]
+    #[cfg(target_os = "linux")]
     prctl::set_dumpable(false)?;
 
     let conn = Connection::connect_to_env()?;


### PR DESCRIPTION
- bump `nix` to 0.31.3, which contains wrappers for timerfd on freebsd
- enable `prctl` call on linux targets only
- enable `allowEmptyPassword` configuration option on linuxpam only, this option does not exist in openpam. update configuration docs to reflect this.

closes #14