### PR TITLE
refactor: remove dependency on linux timerfd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,18 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +972,6 @@ dependencies = [
  "config",
  "dirs",
  "gdk-pixbuf",
- "mio",
  "nix",
  "pam-rs",
  "pango",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap_complete = "4.5.64"
 config = "0.15.18"
 dirs = "6.0.0"
 gdk-pixbuf = "0.21.5"
-mio = { version = "1.1.1", features = ["os-ext", "os-poll"] }
 nix = { version = "0.31.3", features = ["event", "fs", "mman", "process", "time"] }
 pam-rs = "0.9.5"
 pango = "0.22.0"

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,20 +2,20 @@
 // Copyright (C) 2026, Nathan Gill
 
 use std::{
-    os::fd::{AsFd, AsRawFd, BorrowedFd},
+    os::fd::{AsRawFd, BorrowedFd},
     sync::atomic::Ordering,
 };
 
 use anyhow::{Result, anyhow};
-use mio::{Events, Interest, Poll, Token, unix::SourceFd};
-use nix::{
-    sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags},
-    unistd::read,
-};
+use nix::errno::Errno;
 use tracing::warn;
 use wayland_client::{EventQueue, QueueHandle, backend::ReadEventsGuard};
 
-use crate::{auth::AuthState, state::NLockState, util::is_eintr};
+use crate::{
+    auth::AuthState,
+    event_loop::{Event, EventSource, EventTag},
+    state::NLockState,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(usize)]
@@ -37,133 +37,66 @@ impl EventType {
     }
 }
 
+impl From<EventType> for EventTag {
+    fn from(value: EventType) -> Self {
+        value as usize
+    }
+}
+
 impl NLockState {
-    pub fn set_timer(&mut self, id: usize, expiration: Expiration) -> Result<()> {
-        let repeat_timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
-        repeat_timer.set(expiration, TimerSetTimeFlags::empty())?;
-
-        let mut repeat_timer_src = SourceFd(&repeat_timer.as_fd().as_raw_fd());
-
-        let poll = self
-            .poll
-            .as_mut()
-            .ok_or(anyhow!("Poll has not been created yet"))?;
-
-        poll.registry()
-            .register(&mut repeat_timer_src, Token(id), Interest::READABLE)?;
-
-        self.timers.push((repeat_timer, id));
-
-        Ok(())
-    }
-
-    pub fn unset_timer(&mut self, id: usize) -> Result<()> {
-        let poll = self
-            .poll
-            .as_mut()
-            .ok_or(anyhow!("Poll has not been created yet"))?;
-
-        let mut i = 0;
-        while i < self.timers.len() {
-            if self.timers[i].1 == id {
-                poll.registry()
-                    .deregister(&mut SourceFd(&self.timers[i].0.as_fd().as_raw_fd()))?;
-                self.timers.swap_remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn setup_poll(&mut self) -> Result<()> {
-        let poll = Poll::new()?;
-
-        // Register the auth response file descriptor
-        poll.registry().register(
-            &mut SourceFd(&self.auth_comm.response.rx().as_raw_fd()),
-            Token(EventType::AuthStateChanged as usize),
-            Interest::READABLE,
+    fn poll_events(&mut self, wayland_sock_fd: BorrowedFd<'_>) -> Result<Vec<Event>> {
+        self.event_loop.add(
+            EventSource::Fd(wayland_sock_fd.as_raw_fd()),
+            EventType::Wayland.into(),
         )?;
 
-        self.poll = Some(poll);
-        Ok(())
-    }
+        let events = match self.event_loop.poll() {
+            Ok(evs) => evs,
+            Err(Errno::EINTR) => Vec::new(),
+            Err(e) => return Err(anyhow!("Error during poll: {e}")),
+        };
 
-    fn poll_events(&mut self, events: &mut Events, wayland_sock_fd: BorrowedFd<'_>) -> Result<()> {
-        let mut wayland_sock_src = SourceFd(&wayland_sock_fd.as_raw_fd());
+        self.event_loop.remove(EventType::Wayland.into());
 
-        let poll = self
-            .poll
-            .as_mut()
-            .ok_or(anyhow!("Poll has not been created yet"))?;
-
-        {
-            // Register the Wayland file descriptor with the poll
-            poll.registry().register(
-                &mut wayland_sock_src,
-                Token(EventType::Wayland as usize),
-                Interest::READABLE,
-            )?;
-
-            match poll.poll(events, None) {
-                Ok(_) => {}
-                Err(e) if is_eintr(&e) => {}
-                Err(e) => return Err(anyhow!("Error during epoll: {e}")),
-            }
-
-            poll.registry().deregister(&mut wayland_sock_src)?;
-        }
-
-        Ok(())
+        Ok(events)
     }
 
     fn process_events(
         &mut self,
-        events: &Events,
+        events: Vec<Event>,
         read_guard: ReadEventsGuard,
         event_queue: &mut EventQueue<NLockState>,
     ) -> Result<()> {
         let mut wayland_sock_ready = false;
         for event in events {
-            match EventType::from_usize(event.token().0)? {
-                EventType::Wayland => {
-                    wayland_sock_ready = true;
-                }
-                EventType::KeyboardRepeat => {
-                    if let Some(idx) = self
-                        .timers
-                        .iter()
-                        .position(|timer| timer.1 == EventType::KeyboardRepeat as usize)
-                    {
-                        let timer = &self.timers[idx];
-                        let mut buf = [0u8; std::mem::size_of::<u64>()];
-                        let res = read(&timer.0, &mut buf)?;
-                        if res == std::mem::size_of::<u64>() {
-                            let intervals = u64::from_ne_bytes(buf);
-                            for _ in 0..intervals {
-                                self.handle_repeat_event();
-                            }
+            match event {
+                Event::Readable { fd: _, tag } => match EventType::from_usize(tag)? {
+                    EventType::Wayland => {
+                        wayland_sock_ready = true;
+                    }
+                    EventType::AuthStateChanged => match self.auth_comm.response.read() {
+                        Ok(true) => {
+                            // auth was successful, set flags for exit
+                            self.auth_state.store(AuthState::Success, Ordering::Relaxed);
+                            self.running.store(false, Ordering::Relaxed);
+                            self.state_changed.store(true, Ordering::Relaxed);
                         }
+                        Ok(false) => {
+                            // auth failed, set fail state
+                            self.auth_state.store(AuthState::Fail, Ordering::Relaxed);
+                            self.state_changed.store(true, Ordering::Relaxed);
+                        }
+                        Err(e) => {
+                            warn!("Failed to receive auth response: {e}");
+                        }
+                    },
+                    _ => {}
+                },
+                Event::Timeout { tag } => {
+                    if EventType::from_usize(tag)? == EventType::KeyboardRepeat {
+                        self.handle_repeat_event();
                     }
                 }
-                EventType::AuthStateChanged => match self.auth_comm.response.read() {
-                    Ok(true) => {
-                        // auth was successful, set flags for exit
-                        self.auth_state.store(AuthState::Success, Ordering::Relaxed);
-                        self.running.store(false, Ordering::Relaxed);
-                        self.state_changed.store(true, Ordering::Relaxed);
-                    }
-                    Ok(false) => {
-                        // auth failed, set fail state
-                        self.auth_state.store(AuthState::Fail, Ordering::Relaxed);
-                        self.state_changed.store(true, Ordering::Relaxed);
-                    }
-                    Err(e) => {
-                        warn!("Failed to receive auth response: {e}");
-                    }
-                },
             }
         }
 
@@ -200,12 +133,6 @@ impl NLockState {
     }
 
     pub fn event_loop_cycle(&mut self, event_queue: &mut EventQueue<NLockState>) -> Result<()> {
-        if self.poll.is_none() {
-            self.setup_poll()?;
-        }
-
-        let mut events = Events::with_capacity(64);
-
         event_queue.flush()?;
         event_queue.dispatch_pending(self)?;
 
@@ -214,8 +141,8 @@ impl NLockState {
             .ok_or(anyhow!("Failed to obtain Wayland event read guard"))?;
         let wayland_sock_fd = read_guard.connection_fd();
 
-        self.poll_events(&mut events, wayland_sock_fd)?;
-        self.process_events(&events, read_guard, event_queue)?;
+        let events = self.poll_events(wayland_sock_fd)?;
+        self.process_events(events, read_guard, event_queue)?;
         self.re_render(&event_queue.handle());
 
         Ok(())

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,0 +1,179 @@
+use std::{
+    os::fd::RawFd,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Result, bail};
+use nix::{errno::Errno, libc, poll::PollTimeout};
+use tracing::trace;
+
+pub type EventTag = usize;
+
+pub type PollResult<T> = std::result::Result<T, Errno>;
+
+#[derive(Debug)]
+struct TaggedFd {
+    fd: RawFd,
+    tag: EventTag,
+}
+
+#[derive(Debug)]
+struct Timer {
+    interval: Duration,
+    last: Instant,
+    tag: EventTag,
+}
+
+pub enum Event {
+    Readable { fd: RawFd, tag: EventTag },
+    Timeout { tag: EventTag },
+}
+
+pub enum Expiration {
+    Interval(Duration),
+    IntervalDelayed(Duration, Duration),
+}
+
+pub enum EventSource {
+    Fd(RawFd),
+    Timer(Expiration),
+}
+
+pub struct NLockEventLoop {
+    source_fds: Vec<TaggedFd>,
+    timers: Vec<Timer>,
+}
+
+impl NLockEventLoop {
+    pub fn new() -> Self {
+        Self {
+            source_fds: Vec::new(),
+            timers: Vec::new(),
+        }
+    }
+
+    fn next_expiry(&self) -> Option<Duration> {
+        if self.timers.is_empty() {
+            return None;
+        }
+
+        let mut dur = Duration::MAX;
+        for t in &self.timers {
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(t.last);
+
+            if elapsed >= t.interval {
+                // already expired
+                return Some(Duration::ZERO);
+            }
+
+            // this is weird but required to handle delayed timers
+            let left = if t.last > now {
+                t.last.duration_since(now)
+            } else {
+                t.interval - elapsed
+            };
+
+            if left < dur {
+                dur = left;
+            }
+        }
+
+        Some(dur)
+    }
+
+    pub fn poll(&mut self) -> PollResult<Vec<Event>> {
+        let mut events = Vec::new();
+
+        let mut poll_fds: Vec<libc::pollfd> = self
+            .source_fds
+            .iter()
+            .map(|t| libc::pollfd {
+                fd: t.fd,
+                events: libc::POLLIN,
+                revents: 0,
+            })
+            .collect();
+
+        let timeout = self
+            .next_expiry()
+            .map(|d| i32::try_from(d.as_millis()).unwrap_or(i32::MAX))
+            .unwrap_or(PollTimeout::NONE.into());
+
+        let res = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as u64, timeout) };
+        if res == -1 {
+            return Err(Errno::last());
+        }
+
+        for pf in &poll_fds {
+            if pf.revents & libc::POLLIN != 0
+                && let Some(tfd) = self.source_fds.iter().find(|t| t.fd == pf.fd)
+            {
+                let ev = Event::Readable {
+                    fd: tfd.fd,
+                    tag: tfd.tag,
+                };
+                events.push(ev);
+            }
+        }
+
+        for t in &mut self.timers {
+            let now = Instant::now();
+            let elapsed = now - t.last;
+            if elapsed >= t.interval {
+                let ev = Event::Timeout { tag: t.tag };
+                t.last = now;
+                events.push(ev);
+            }
+        }
+
+        Ok(events)
+    }
+
+    pub fn add(&mut self, source: EventSource, tag: EventTag) -> Result<()> {
+        match source {
+            EventSource::Fd(fd) => {
+                let tfd = TaggedFd { fd, tag };
+                trace!("added event source: {:?}", tfd);
+                self.source_fds.push(tfd);
+            }
+            EventSource::Timer(expiration) => {
+                let (delay, interval) = match expiration {
+                    Expiration::Interval(interval) => (None, interval),
+                    Expiration::IntervalDelayed(delay, interval) => (Some(delay), interval),
+                };
+
+                if interval.is_zero() {
+                    bail!("timer interval cannot be set to zero!");
+                }
+
+                let timer = Timer {
+                    interval,
+                    last: if let Some(delay) = delay {
+                        // offset next interval by delay
+                        Instant::now() + delay - interval
+                    } else {
+                        Instant::now()
+                    },
+                    tag,
+                };
+                trace!("added timer: {:?}", timer);
+                self.timers.push(timer);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn remove(&mut self, tag: EventTag) {
+        self.source_fds.retain(|t| t.tag != tag);
+        self.timers.retain(|t| t.tag != tag);
+        trace!("removed tag: {:?}", tag);
+    }
+}
+
+impl Default for NLockEventLoop {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod cairo_ext;
 pub mod comm;
 pub mod config;
 pub mod event;
+pub mod event_loop;
 pub mod render;
 pub mod seat;
 pub mod state;

--- a/src/seat.rs
+++ b/src/seat.rs
@@ -4,7 +4,6 @@
 use std::{os::fd::OwnedFd, sync::atomic::Ordering, time::Duration};
 
 use anyhow::{Result, anyhow};
-use nix::sys::{time::TimeSpec, timerfd::Expiration};
 use tracing::{debug, warn};
 use wayland_client::{
     Connection, Dispatch, QueueHandle, WEnum,
@@ -12,7 +11,11 @@ use wayland_client::{
 };
 use xkbcommon::xkb;
 
-use crate::{event::EventType, state::NLockState};
+use crate::{
+    event::EventType,
+    event_loop::{EventSource, Expiration},
+    state::NLockState,
+};
 
 pub struct NLockXkb {
     pub context: xkb::Context,
@@ -122,11 +125,8 @@ impl NLockState {
             self.process_key(keysym, codepoint);
         }
 
-        if self.seat.repeat_timer_set
-            && let Err(e) = self.unset_timer(EventType::KeyboardRepeat as usize)
-        {
-            return Err(e);
-        } else {
+        if self.seat.repeat_timer_set {
+            self.event_loop.remove(EventType::KeyboardRepeat.into());
             self.seat.repeat_timer_set = false;
         }
 
@@ -138,13 +138,12 @@ impl NLockState {
 
             let repeat_delay_duration = Duration::from_millis(self.seat.repeat_delay as u64);
             let repeat_rate_duration = Duration::from_millis(self.seat.repeat_rate as u64);
-
-            self.set_timer(
-                EventType::KeyboardRepeat as usize,
-                Expiration::IntervalDelayed(
-                    TimeSpec::from_duration(repeat_delay_duration),
-                    TimeSpec::from_duration(repeat_rate_duration),
-                ),
+            self.event_loop.add(
+                EventSource::Timer(Expiration::IntervalDelayed(
+                    repeat_delay_duration,
+                    repeat_rate_duration,
+                )),
+                EventType::KeyboardRepeat.into(),
             )?;
 
             self.seat.repeat_timer_set = true;

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,14 +4,13 @@
 use std::{
     fs::File,
     io::Seek,
+    os::fd::AsRawFd,
     sync::{Arc, atomic::AtomicBool},
 };
 
 use anyhow::{Result, anyhow, bail};
 use cairo::ImageSurface;
 use gdk_pixbuf::Pixbuf;
-use mio::Poll;
-use nix::sys::timerfd::TimerFd;
 use tracing::{debug, warn};
 use wayland_client::protocol::{wl_region, wl_subcompositor, wl_subsurface};
 use wayland_client::{
@@ -26,16 +25,16 @@ use wayland_protocols::ext::session_lock::v1::client::{
 };
 use zeroize::Zeroizing;
 
-use crate::config::NLockConfig;
-use crate::util::BackgroundType;
 use crate::{
     auth::AuthChannel,
     cairo_ext::{ImageSurfaceExt, SubpixelOrderExt},
+    event_loop::{EventSource, NLockEventLoop},
 };
 use crate::{
     auth::{AtomicAuthState, AuthState},
     util::detect_png,
 };
+use crate::{config::NLockConfig, event::EventType, util::BackgroundType};
 use crate::{
     seat::{NLockSeat, NLockXkb},
     surface::NLockSurface,
@@ -59,11 +58,10 @@ pub struct NLockState {
     pub seat: NLockSeat,
     pub xkb: NLockXkb,
     pub password: Zeroizing<String>,
-    pub poll: Option<Poll>,
-    pub timers: Vec<(TimerFd, usize)>,
     pub auth_comm: Arc<AuthChannel>,
     pub auth_state: Arc<AtomicAuthState>,
     pub background_image: Option<cairo::ImageSurface>,
+    pub event_loop: NLockEventLoop,
 }
 
 impl NLockState {
@@ -90,11 +88,10 @@ impl NLockState {
             seat: NLockSeat::default(),
             xkb: NLockXkb::default(),
             password: Zeroizing::new("".to_string()),
-            poll: None,
-            timers: Vec::new(),
             auth_comm,
             auth_state: Arc::new(AtomicAuthState::new(AuthState::Idle)),
             background_image: None,
+            event_loop: NLockEventLoop::default(),
         };
 
         if let Err(e) = s.try_load_background_image() {
@@ -104,6 +101,11 @@ impl NLockState {
                 e
             );
         }
+
+        s.event_loop.add(
+            EventSource::Fd(s.auth_comm.response.rx().as_raw_fd()),
+            EventType::AuthStateChanged.into(),
+        )?;
 
         Ok(s)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,6 @@ use std::{
 use clap::ValueEnum;
 use nix::{
     fcntl::OFlag,
-    libc,
     sys::{
         mman::{shm_open, shm_unlink},
         stat::Mode,
@@ -222,14 +221,6 @@ pub fn pango_pixels(d: i32) -> i32 {
 
 // Pango scale factor
 pub const PANGO_SCALE: i32 = 1024;
-
-// This helper function just checks if an `std::io::Error` was an EINTR
-pub fn is_eintr(err: &std::io::Error) -> bool {
-    match err.raw_os_error() {
-        Some(code) => code == libc::EINTR,
-        None => false,
-    }
-}
 
 const PNG_SIG: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
 


### PR DESCRIPTION
- remove dependency on `mio` with a new event system
- remove dependency on the linux-specific timerfd API by moving timers to userspace
- one step closer to POSIX!