### PR TITLE
fix(event_loop): cast to `nfds_t` rather than assuming `u64`

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -97,10 +97,16 @@ impl NLockEventLoop {
 
         let timeout = self
             .next_expiry()
-            .map(|d| i32::try_from(d.as_millis()).unwrap_or(i32::MAX))
+            .map(|d| libc::c_int::try_from(d.as_millis()).unwrap_or(libc::c_int::MAX))
             .unwrap_or(PollTimeout::NONE.into());
 
-        let res = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as u64, timeout) };
+        let res = unsafe {
+            libc::poll(
+                poll_fds.as_mut_ptr(),
+                poll_fds.len() as libc::nfds_t,
+                timeout,
+            )
+        };
         if res == -1 {
             return Err(Errno::last());
         }


### PR DESCRIPTION
- some libc implementations, e.g. FreeBSD, define `nfds_t` as a uint rather than a ulong, `nfds_t` will reflect this properly
- apply similar measures when using integers around raw `poll`