### PR TITLE
feat: move `gdk-pixbuf` support behind an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.53", features = ["derive"] }
 clap_complete = "4.5.64"
 config = "0.15.18"
 dirs = "6.0.0"
-gdk-pixbuf = "0.21.5"
+gdk-pixbuf = { version = "0.21.5", optional = true }
 nix = { version = "0.31.3", features = ["event", "fs", "mman", "process", "time"] }
 pam-rs = "0.9.5"
 pango = "0.22.0"
@@ -25,6 +25,10 @@ wayland-client = "0.31.11"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
 xkbcommon = "0.9.0"
 zeroize = "1.8.2"
+
+[features]
+default = ["gdk-pixbuf"]
+gdk-pixbuf = ["dep:gdk-pixbuf"]
 
 [build-dependencies]
 time = { version = "0.3.47", features = ["formatting"] }

--- a/src/cairo_ext.rs
+++ b/src/cairo_ext.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026, Nathan Gill
 
-use anyhow::{Result, anyhow};
-use cairo::{Context, Format, ImageSurface, SubpixelOrder};
-use gdk_pixbuf::Pixbuf;
+use cairo::{Context, SubpixelOrder};
 use wayland_client::{WEnum, protocol::wl_output};
 
 use crate::util::Rgba;
@@ -39,88 +37,100 @@ impl SubpixelOrderExt for SubpixelOrder {
     }
 }
 
-pub trait ImageSurfaceExt {
-    fn create_from_pixbuf(pixbuf: &Pixbuf) -> Result<ImageSurface>;
-}
+#[cfg(feature = "gdk-pixbuf")]
+mod pixbuf_ext {
+    use {
+        anyhow::{Result, anyhow},
+        cairo::{Format, ImageSurface},
+        gdk_pixbuf::Pixbuf,
+    };
 
-#[inline]
-fn premul(c: u16, a: u16) -> u8 {
-    let z = (c * a) + 0x80;
-    ((z + (z >> 8)) >> 8) as u8
-}
+    pub trait ImageSurfaceExt {
+        fn create_from_pixbuf(pixbuf: &Pixbuf) -> Result<ImageSurface>;
+    }
 
-impl ImageSurfaceExt for ImageSurface {
-    /// Create an `ImageSurface` from a `Pixbuf`
-    ///
-    /// The API to do this was removed from GTK :(, so this is a version ported
-    /// from swaylock, that essentially does the same thing.
-    fn create_from_pixbuf(pixbuf: &Pixbuf) -> Result<ImageSurface> {
-        let chan = pixbuf.n_channels() as usize;
-        if chan < 3 {
-            return Err(anyhow!(cairo::Error::InvalidFormat));
-        }
+    #[inline]
+    fn premul(c: u16, a: u16) -> u8 {
+        let z = (c * a) + 0x80;
+        ((z + (z >> 8)) >> 8) as u8
+    }
 
-        let pixels = pixbuf.read_pixel_bytes();
-        let width = pixbuf.width() as usize;
-        let height = pixbuf.height() as usize;
-        let stride = pixbuf.rowstride() as usize;
+    impl ImageSurfaceExt for ImageSurface {
+        /// Create an `ImageSurface` from a `Pixbuf`
+        ///
+        /// The API to do this was removed from GTK :(, so this is a version ported
+        /// from swaylock, that essentially does the same thing.
+        fn create_from_pixbuf(pixbuf: &Pixbuf) -> Result<ImageSurface> {
+            let chan = pixbuf.n_channels() as usize;
+            if chan < 3 {
+                return Err(anyhow!(cairo::Error::InvalidFormat));
+            }
 
-        let fmt = if chan == 3 {
-            Format::Rgb24
-        } else {
-            Format::ARgb32
-        };
+            let pixels = pixbuf.read_pixel_bytes();
+            let width = pixbuf.width() as usize;
+            let height = pixbuf.height() as usize;
+            let stride = pixbuf.rowstride() as usize;
 
-        let mut surface = ImageSurface::create(fmt, width as i32, height as i32)?;
-        surface.flush();
+            let fmt = if chan == 3 {
+                Format::Rgb24
+            } else {
+                Format::ARgb32
+            };
 
-        {
-            let cstride = surface.stride() as usize;
-            let mut cpixels = surface.data()?;
+            let mut surface = ImageSurface::create(fmt, width as i32, height as i32)?;
+            surface.flush();
 
-            for y in 0..height {
-                let goff = y * stride;
-                let coff = y * cstride;
+            {
+                let cstride = surface.stride() as usize;
+                let mut cpixels = surface.data()?;
 
-                let grow = &pixels[goff..goff + chan * width];
-                let crow = &mut cpixels[coff..coff + 4 * width];
+                for y in 0..height {
+                    let goff = y * stride;
+                    let coff = y * cstride;
 
-                for x in 0..width {
-                    let src = &grow[chan * x..chan * x + chan];
-                    let dst = &mut crow[4 * x..4 * x + 4];
+                    let grow = &pixels[goff..goff + chan * width];
+                    let crow = &mut cpixels[coff..coff + 4 * width];
 
-                    if fmt == Format::Rgb24 {
-                        if cfg!(target_endian = "little") {
-                            dst[0] = src[2];
-                            dst[1] = src[1];
-                            dst[2] = src[0];
-                            dst[3] = 0;
+                    for x in 0..width {
+                        let src = &grow[chan * x..chan * x + chan];
+                        let dst = &mut crow[4 * x..4 * x + 4];
+
+                        if fmt == Format::Rgb24 {
+                            if cfg!(target_endian = "little") {
+                                dst[0] = src[2];
+                                dst[1] = src[1];
+                                dst[2] = src[0];
+                                dst[3] = 0;
+                            } else {
+                                dst[0] = 0;
+                                dst[1] = src[0];
+                                dst[2] = src[1];
+                                dst[3] = src[2];
+                            }
                         } else {
-                            dst[0] = 0;
-                            dst[1] = src[0];
-                            dst[2] = src[1];
-                            dst[3] = src[2];
-                        }
-                    } else {
-                        let a = src[3] as u16;
+                            let a = src[3] as u16;
 
-                        if cfg!(target_endian = "little") {
-                            dst[0] = premul(src[2] as u16, a);
-                            dst[1] = premul(src[1] as u16, a);
-                            dst[2] = premul(src[0] as u16, a);
-                            dst[3] = a as u8;
-                        } else {
-                            dst[0] = a as u8;
-                            dst[1] = premul(src[0] as u16, a);
-                            dst[2] = premul(src[1] as u16, a);
-                            dst[3] = premul(src[2] as u16, a);
+                            if cfg!(target_endian = "little") {
+                                dst[0] = premul(src[2] as u16, a);
+                                dst[1] = premul(src[1] as u16, a);
+                                dst[2] = premul(src[0] as u16, a);
+                                dst[3] = a as u8;
+                            } else {
+                                dst[0] = a as u8;
+                                dst[1] = premul(src[0] as u16, a);
+                                dst[2] = premul(src[1] as u16, a);
+                                dst[3] = premul(src[2] as u16, a);
+                            }
                         }
                     }
                 }
             }
-        }
 
-        surface.mark_dirty();
-        Ok(surface)
+            surface.mark_dirty();
+            Ok(surface)
+        }
     }
 }
+
+#[cfg(feature = "gdk-pixbuf")]
+pub use pixbuf_ext::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,11 @@ fn main() {
     match NLockConfig::load(&args) {
         Ok(cfg) => {
             if let Err(e) = start(cfg) {
-                error!("{:#?}", e);
+                error!("{:?}", e);
             }
         }
         Err(e) => {
-            error!("Error loading configuration: {:#?}", e);
+            error!("Error loading configuration: {:?}", e);
             return;
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,6 @@ use std::{
 
 use anyhow::{Result, anyhow, bail};
 use cairo::ImageSurface;
-use gdk_pixbuf::Pixbuf;
 use tracing::{debug, warn};
 use wayland_client::protocol::{wl_region, wl_subcompositor, wl_subsurface};
 use wayland_client::{
@@ -25,9 +24,12 @@ use wayland_protocols::ext::session_lock::v1::client::{
 };
 use zeroize::Zeroizing;
 
+#[cfg(feature = "gdk-pixbuf")]
+use {crate::cairo_ext::ImageSurfaceExt, gdk_pixbuf::Pixbuf};
+
 use crate::{
     auth::AuthChannel,
-    cairo_ext::{ImageSurfaceExt, SubpixelOrderExt},
+    cairo_ext::SubpixelOrderExt,
     event_loop::{EventSource, NLockEventLoop},
 };
 use crate::{
@@ -171,13 +173,23 @@ impl NLockState {
             let image_surface = ImageSurface::create_from_png(&mut image_file)?;
             self.background_image = Some(image_surface);
         } else {
-            let pixbuf = Pixbuf::from_read(image_file)?;
-            let pixbuf = pixbuf
-                .apply_embedded_orientation()
-                .ok_or(anyhow!("Failed to apply embedded image orientation"))?;
+            #[cfg(feature = "gdk-pixbuf")]
+            {
+                let pixbuf = Pixbuf::from_read(image_file)?;
+                let pixbuf = pixbuf
+                    .apply_embedded_orientation()
+                    .ok_or(anyhow!("Failed to apply embedded image orientation"))?;
 
-            let image_surface = ImageSurface::create_from_pixbuf(&pixbuf)?;
-            self.background_image = Some(image_surface);
+                let image_surface = ImageSurface::create_from_pixbuf(&pixbuf)?;
+                self.background_image = Some(image_surface);
+            }
+
+            #[cfg(not(feature = "gdk-pixbuf"))]
+            {
+                return Err(anyhow!(
+                    "Non-PNG formats require GDK-Pixbuf support, but nlock was compiled without it"
+                ));
+            }
         }
 
         self.config.general.bg_type = BackgroundType::Image;


### PR DESCRIPTION
- support gdk-pixbuf as an optional feature, since it's not required anyway. this feature is enabled by default.